### PR TITLE
prevent to go on out of ranges page

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -583,16 +583,14 @@ EPUBJS.Book.prototype.prevPage = function() {
 };
 
 EPUBJS.Book.prototype.nextChapter = function() {
-	this.spinePos++;
 	if(this.spinePos > this.spine.length) return;
-	
+	this.spinePos++;
 	return this.displayChapter(this.spinePos);
 };
 
 EPUBJS.Book.prototype.prevChapter = function() {
+	if(this.spinePos < 1) return;
 	this.spinePos--;
-	if(this.spinePos < 0) return;
-	
 	return this.displayChapter(this.spinePos, true);
 };
 


### PR DESCRIPTION
When you're on first page and click prevPage button several times, rendered page doesn't change but you have to click several times nextPage button to go to second page. The same happens on last page. This commit fixed it.
