### PR TITLE
fixes futurepress/epub.js#103

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -536,6 +536,13 @@ EPUBJS.Book.prototype.displayChapter = function(chap, end){
 		}
 		
 	});
+	
+	render = render.then(function() {
+		var deferred = new RSVP.defer();
+		setTimeout(function() { deferred.resolve() }, 0)
+		return deferred.promise
+	}.bind(this))
+	
 	return render;
 };
 


### PR DESCRIPTION
(AFAIK) this yields to the browser renderer, rendering the chapter before the calculation of the 'jump' location when navigating to a location in the document.
