### PR TITLE
Simple fix to the Reader example

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,7 @@
                 EPUBJS.cssPath = "css/";
                 // fileStorage.filePath = EPUBJS.filePath;
 
-                var reader = ePubReader("moby-dick/");
+                window.Reader = ePubReader("moby-dick/");
               }  
             };
         


### PR DESCRIPTION
Fixes #106
There is a slight discrepency between the demo/index.html and demo/dev.html, meaning that only demo/dev.html works. This brings them into synchrony, and fixes the reader example.
