### PR TITLE
Fix to the reader example

### DIFF
--- a/reader/controllers/reader_controller.js
+++ b/reader/controllers/reader_controller.js
@@ -5,8 +5,10 @@ EPUBJS.reader.ReaderController = function(book) {
 			$next = $("#next"),
 			$prev = $("#prev");
 
+	var reader = this
+
 	var slideIn = function() {
-        if (Reader.settings.sidebarReflow){
+        if (reader.settings.sidebarReflow){
                 $('#main').removeClass('single');
         } else {
                 $main.removeClass("closed");
@@ -14,7 +16,7 @@ EPUBJS.reader.ReaderController = function(book) {
     };
 
     var slideOut = function() {
-        if (Reader.settings.sidebarReflow){
+        if (reader.settings.sidebarReflow){
                 $('#main').addClass('single');
         } else {
                 $main.addClass("closed");


### PR DESCRIPTION
fixes #106
This patch continues the commit futurepress/epub.js@816b694be05411a0eb7f59860307974a04f405c1 , which left a couple of references out (which prevented the reader example from working).
