### PR TITLE
Prevent iframe from pushing history state to parent window's history

### DIFF
--- a/src/render_iframe.js
+++ b/src/render_iframe.js
@@ -31,7 +31,7 @@ EPUBJS.Render.Iframe.prototype.load = function(url){
 	var render = this,
 			deferred = new RSVP.defer();
 
-	this.iframe.src = url;
+	this.iframe.contentWindow.location.replace(url);
 
 	// Reset the scroll position
 	render.leftPos = 0;


### PR DESCRIPTION
I am working on a project that is using epub.js and I realized whenever a new chapter is rendered, it will push a state to the history of the parent window. Setting the contentWindow location instead of the iframe's "src" attribute will prevent this to happen.
