### PR TITLE
Fix table of contents issues with nested items

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -331,8 +331,8 @@ EPUBJS.Parser.prototype.toc = function(tocXml, spineIndexByURL, bookSpine){
 	if(!navMap) return [];
 	
 	function getTOC(parent){
+		var nodes = (parent.querySelectorAll("navMap > navPoint").length > 0 ? parent.querySelectorAll("navMap > navPoint") : parent.querySelectorAll("navPoint"));
 		var list = [],
-				nodes = parent.querySelectorAll("navPoint"),
 				items = Array.prototype.slice.call(nodes).reverse(),
 				length = items.length,
 				iter = length,


### PR DESCRIPTION
The table of contents was correctly displaying subitems as a list within the chapter list, but it was also incorrectly displaying the subitems as top-level items after the chapter item. This seems to be because the `getTOC` method iterates over all of the `navPoint` items and is used recursively without distinguishing between top-level items and subitems.

I added a ternary operator to account for this when setting the `nodes` variable and it seems to handle the table of contents more predictably (i.e. the subitems aren't displayed as top-level items anymore). There might be a better way to handle this in the future but this works for now.

Fixes #122 and fixes #129.
