### PR TITLE
fix #147 - plugin not loading all chapters

### DIFF
--- a/build/epub.js
+++ b/build/epub.js
@@ -3080,12 +3080,12 @@ EPUBJS.Book.prototype.prevPage = function() {
 
 EPUBJS.Book.prototype.nextChapter = function() {
 	var next;
-	if (this.spinePos < this.spine.length - 1) {
+	if (this.spinePos < this.spine.length ) {
 		next = this.spinePos + 1;
 		while (this.spine[next] && this.spine[next].linear && this.spine[next].linear == 'no') {
 			next++;
 		}
-		if (next < this.spine.length - 1) {
+		if (next < this.spine.length ) {
 			return this.displayChapter(next);
 		} else {
 			this.trigger("book:atEnd");


### PR DESCRIPTION
Why it's using the **if (this.spinePos < this.spine.length - 1)**, if I'm using **array length** and the operator **<**, do I need to the **\- 1** ? 
This change fix the issue #147
