### PR TITLE
Fix compatibility with wicked-good-xpath

### DIFF
--- a/src/epubcfi.js
+++ b/src/epubcfi.js
@@ -478,7 +478,7 @@ EPUBJS.EpubCFI.prototype.generateRangeFromCfi = function(cfi, _doc) {
 	
 	// Get the terminal step
 	lastStep = cfi.steps[cfi.steps.length-1];
-	startContainer = doc.evaluate(xpath, doc, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+	startContainer = document.evaluate(xpath, doc, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
 
 	if(!startContainer) {
 		return null;


### PR DESCRIPTION
Small change to make epub.js be compatible with wicked-good-xpath and run on IE11. (Tested with IE11/WinRT 8.1)