### PR TITLE
Propagate geturl error when the store can't lookup the url

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -77,9 +77,12 @@ EPUBJS.replace.links = function(_store, full, done, link){
 			}, 5); //-- Allow for css to apply before displaying chapter
 		});
 	}else{
-		_store.getUrl(full).then(done);
-	}
-};
+                _store.getUrl(full).then(done, function(reason) {
+                    // we were unable to get the url, signal to upper layer
+                    done(null);
+                });
+        }
+  };
 
 EPUBJS.replace.stylesheets = function(_store, full) {
 	var deferred = new RSVP.defer();

--- a/src/replace.js
+++ b/src/replace.js
@@ -77,12 +77,12 @@ EPUBJS.replace.links = function(_store, full, done, link){
 			}, 5); //-- Allow for css to apply before displaying chapter
 		});
 	}else{
-                _store.getUrl(full).then(done, function(reason) {
-                    // we were unable to get the url, signal to upper layer
-                    done(null);
-                });
-        }
-  };
+		_store.getUrl(full).then(done, function(reason) {
+			// we were unable to get the url, signal to upper layer
+			done(null);
+		});
+	}
+};
 
 EPUBJS.replace.stylesheets = function(_store, full) {
 	var deferred = new RSVP.defer();


### PR DESCRIPTION
We came across an epub file containing
    <link href="./files/editdata.mso" rel="Edit-Time-Data" />
in a html head - but the file was not contained in the epub.

Epub.js got stuck while trying to render it, as ```EPUBJS.Renderer.prototype.replace``` is waiting for all funcs to complete.
This patch calls the done callback with a dummy value to allow rendering to continue in that case.
It's not nice, but it does the job.