### PR TITLE
Propagate gettext error

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -75,6 +75,9 @@ EPUBJS.replace.links = function(_store, full, done, link){
 			setTimeout(function(){
 				done(url, full);
 			}, 5); //-- Allow for css to apply before displaying chapter
+		},  function(reason) {
+			// we were unable to replace the style sheets
+			done(null);
 		});
 	}else{
 		_store.getUrl(full).then(done, function(reason) {
@@ -100,10 +103,12 @@ EPUBJS.replace.stylesheets = function(_store, full) {
 
 			deferred.resolve(url);
 
-		}, function(e) {
-			console.error(e);
+		}, function(reason) {
+			deferred.reject(reason);
 		});
 		
+	}, function(reason) {
+		deferred.reject(reason);
 	});
 
 	return deferred.promise;

--- a/src/unarchiver.js
+++ b/src/unarchiver.js
@@ -68,7 +68,10 @@ EPUBJS.Unarchiver.prototype.getText = function(url, encoding){
 	var _URL = window.URL || window.webkitURL || window.mozURL;
 
 	if(!entry) {
-		console.warn("File not found in the contained epub:", url);
+		deferred.reject({
+			message : "File not found in the epub: " + url,
+			stack : new Error().stack
+		});
 		return deferred.promise;
 	}
 


### PR DESCRIPTION
This time we came across an epub file that had a reference to a style sheet that was not included in the archive.
This pull request allows epub.js to continue in case of that error.

Due to multiple calls to reject() multiple errors will be logged to the console in this case.

