### PR TITLE
propapage the getUrl()-error up through replace.cssUrls()

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -129,9 +129,11 @@ EPUBJS.replace.cssUrls = function(_store, base, text){
 	matches.forEach(function(str){
 		var full = EPUBJS.core.resolveUrl(base, str.replace(/url\(|[|\)|\'|\"]/g, ''));
 		var replaced = _store.getUrl(full).then(function(url){
-				text = text.replace(str, 'url("'+url+'")');
-			});
-		
+			text = text.replace(str, 'url("'+url+'")');
+		}, function(reason) {
+			deferred.reject(reason);
+		});
+                       		
 		promises.push(replaced);
 	});
 	


### PR DESCRIPTION
This time we came across an epub file that had a css file referring to a font file that was not included in the archive.
This pull request allows epub.js to continue in case of that error.