### PR TITLE
Allow opening file other than demo

### DIFF
--- a/reader/index.html
+++ b/reader/index.html
@@ -25,7 +25,9 @@
                 EPUBJS.cssPath = "css/";
                 // fileStorage.filePath = EPUBJS.filePath;
 
-                var reader = ePubReader("moby-dick/");
+                var qs = {};
+                window.location.search.substring(1).split('&').forEach(function(el) {el = el.split('=');qs[el[0]] = decodeURIComponent(el[1]);});
+                var reader = ePubReader(qs.file || "moby-dick/");
               }  
             };
         


### PR DESCRIPTION
I  made a simple change to the demo reader to allow using it on any file, instead of just Moby Dick. The file to be opened is passed on the URL, in the `file` query parameter. 