### PR TITLE
Preserve file:// protocol for local links

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -16,6 +16,7 @@ EPUBJS.replace.hrefs = function(callback, renderer){
 			link.setAttribute("target", "_blank");
 
 		}else{
+		    // Links may need to be resolved, such as ../chp1.xhtml
             var uri = EPUBJS.core.uri(renderer.render.window.location.href);
 
             directory = uri.directory;

--- a/src/replace.js
+++ b/src/replace.js
@@ -16,13 +16,23 @@ EPUBJS.replace.hrefs = function(callback, renderer){
 			link.setAttribute("target", "_blank");
 
 		}else{
-			// Links may need to be resolved, such as ../chp1.xhtml
-			directory = EPUBJS.core.uri(renderer.render.window.location.href).directory;
-			if(directory) {
-				relative = EPUBJS.core.resolveUrl(directory, href);
-			} else {
-				relative = href;
-			}
+            var uri = EPUBJS.core.uri(renderer.render.window.location.href);
+
+            directory = uri.directory;
+
+            if(directory) {
+                // We must ensure that the file:// protocol is preserved for
+                // local file links, as in certain contexts (such as under
+                // Titanium), file links without the file:// protocol will not
+                // work
+                if (uri.protocol === "file") {
+                    relative = EPUBJS.core.resolveUrl(uri.base, href);
+                } else {
+                    relative = EPUBJS.core.resolveUrl(directory, href);
+                }
+            } else {
+                relative = href;
+            }
 
 			link.onclick = function(){
 				book.goto(relative);


### PR DESCRIPTION
I am currently using epub.js under Titanium for an app I just started to write, and links inside the EPUB were not working. After going through the code, the problem is that Titanium requires the file:// prefix to correctly load files. The same can be said if the epub.js library is used locally, the browser would also require the file:// prefix on links.