### PR TITLE
Fixed reference to renderer when destroying the book

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -1171,7 +1171,7 @@ EPUBJS.Book.prototype.destroy = function() {
 
 	this.unload();
 
-	if(this.render) this.render.remove();
+	if(this.renderer) this.renderer.remove();
 
 };
 


### PR DESCRIPTION
Fixed typo, should be "renderer", not "render". This typo prevented me from loading a new book into the DIV when a previous book was already loaded.
