### PR TITLE
safely check for screenfull

### DIFF
--- a/reader_src/controllers/controls_controller.js
+++ b/reader_src/controllers/controls_controller.js
@@ -38,11 +38,11 @@ EPUBJS.reader.ControlsController = function(book) {
 		}
 	});
 
-	$fullscreen.on("click", function() {
-		screenfull.toggle($('#container')[0]);
-	});
+	if(typeof screenfull !== 'undefined') {
+		$fullscreen.on("click", function() {
+			screenfull.toggle($('#container')[0]);
+		});
 
-	if(screenfull) {
 		document.addEventListener(screenfull.raw.fullscreenchange, function() {
 				fullscreen = screenfull.isFullscreen;
 				if(fullscreen) {


### PR DESCRIPTION
If `screenfull` is not present on the page, this script will throw an error.

Also, there is no reason to bind the `click` handler if `screenfull` isn't available, so I made that conditional too.