### PR TITLE
restore all saved settings

### DIFF
--- a/reader_src/reader.js
+++ b/reader_src/reader.js
@@ -277,7 +277,7 @@ EPUBJS.Reader.prototype.applySavedSettings = function() {
 	}
 		
 		if(stored) {
-			this.settings = _.defaults(this.settings, stored);
+			this.settings = $.extend(true, this.settings, stored);
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
I was trying to make font size persistent, but for some reason my settings were not being restored.

It turns out that `_.defaults` prevents settings which are not `undefined` (such as `null` options, which is what `styles` [defaults to](https://github.com/futurepress/epub.js/blob/5dab45036552bcc1787dd39d9f810a26bfb88cb1/reader_src/reader.js#L45)) from being restored. `$.extend` should restore everything.