### PR TITLE
Pass withCredentials setting to Book

### DIFF
--- a/reader_src/reader.js
+++ b/reader_src/reader.js
@@ -75,7 +75,8 @@ EPUBJS.Reader = function(bookPath, _options) {
 		reload: this.settings.reload,
 		contained: this.settings.contained,
 		bookKey: this.settings.bookKey,
-		styles: this.settings.styles
+		styles: this.settings.styles,
+		withCredentials: this.settings.withCredentials
 	});
 	
 	if(this.settings.previousLocationCfi) {


### PR DESCRIPTION
Passing `withCredentials: true` to `ePubReader` doesn't work, because that setting is not getting passed down to `Book`. I assume there was a good reason for being selective here, so I added it to the list of properties. If there isn't a good reason, you should consider passing all settings down (and, if necessary, update the code so that works), as the interfaces seem to want to mirror each other.