### PR TITLE
Fixed self closing script html tags.

### DIFF
--- a/src/chapter.js
+++ b/src/chapter.js
@@ -64,6 +64,7 @@ EPUBJS.Chapter.prototype.render = function(_store){
 	.then(function(doc) {
 		var serializer = new XMLSerializer();
 		var contents = serializer.serializeToString(doc);
+		contents = contents.replace(/<script(.*)\/>/g, '<script$1></script>');
 		return contents;
 	}.bind(this));
 };


### PR DESCRIPTION
XMLSerializer produces wrong `script` tag syntax.

It serializes `<script src="script.js"></script>` to `<script src="script.js"/>` (not that there is no whitespace between `><`, if you put something between them serializer will work correctly).

The regex adds missing `</script>`.

To reproduce the error create a epub with `<script src="script.js"></script>` tag and try to load the epub to iframe.