### PR TITLE
Fixed resources paths replacement. 

### DIFF
--- a/src/chapter.js
+++ b/src/chapter.js
@@ -371,9 +371,9 @@ EPUBJS.Chapter.prototype.replaceWithStored = function(query, attr, func, callbac
 					}, _wait);
 				}
 
-				link.setAttribute(_attr, url);
-
-
+				if (url) {
+					link.setAttribute(_attr, url);
+				}
 
 			};
 

--- a/src/replace.js
+++ b/src/replace.js
@@ -130,7 +130,7 @@ EPUBJS.replace.stylesheets = function(_store, full) {
 EPUBJS.replace.cssUrls = function(_store, base, text){
 	var deferred = new RSVP.defer(),
 		promises = [],
-		matches = text.match(/url\(\'?\"?([^\'|^\"^\)]*)\'?\"?\)/g);
+		matches = text.match(/url\(\'?\"?((?!data:)[^\'|^\"^\)]*)\'?\"?\)/g);
 
 	if(!_store) return;
 
@@ -140,7 +140,7 @@ EPUBJS.replace.cssUrls = function(_store, base, text){
 	}
 
 	matches.forEach(function(str){
-		var full = EPUBJS.core.resolveUrl(base, str.replace(/url\(|[|\)|\'|\"]/g, ''));
+		var full = EPUBJS.core.resolveUrl(base, str.replace(/url\(|[|\)|\'|\"]|\?.*$/g, ''));
 		var replaced = _store.getUrl(full).then(function(url){
 			text = text.replace(str, 'url("'+url+'")');
 		}, function(reason) {


### PR DESCRIPTION
I found problems when I tried to use some kind of paths in the html or css files. I fixed them in this pull request.

Firstly, I fixed an issue that I had reported (https://github.com/futurepress/epub.js/issues/305). Script tried to find path to the external resource in the epub archive and because it can't find it, script replace path to "null". I added a test, that check if new url isn't null before replacing the path.

The second bug cause problem with parsing stylesheets when they have urls with URI data schema (used for example to describe background image) or path have some query part (used for example for files versioning). I excluded items with data URI from replacement process and removed query part from the path before passing it to the `_store.getUrl` method.