### PR TITLE
Attempt to fix incorrect page end calculations

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -609,7 +609,9 @@ EPUBJS.Renderer.prototype.mapPage = function(){
 	var elLimit = 0;
 	var prevRange;
 	var cfi;
+	var lastChildren = null;
 	var check = function(node) {
+//                console.log( "check", node );
 		var elPos;
 		var elRange;
 		var children = Array.prototype.slice.call(node.childNodes);
@@ -623,6 +625,7 @@ EPUBJS.Renderer.prototype.mapPage = function(){
 				return;
 			}
 
+			lastChildren = children; 
 			//-- Element starts new Col
 			if(elPos.left > elLimit) {
 				children.forEach(function(node){
@@ -631,6 +634,7 @@ EPUBJS.Renderer.prototype.mapPage = function(){
 						checkText(node);
 					}
 				});
+				lastChildren = null;
 			}
 
 			//-- Element Spans new Col
@@ -641,11 +645,13 @@ EPUBJS.Renderer.prototype.mapPage = function(){
 						checkText(node);
 					}
 				});
+				lastChildren = null;
 			}
 		}
 
 	};
 	var checkText = function(node){
+//                console.log( "checkText", node );
 		var ranges = renderer.splitTextNodeIntoWordsRanges(node);
 		ranges.forEach(function(range){
 			var pos = range.getBoundingClientRect();
@@ -694,6 +700,17 @@ EPUBJS.Renderer.prototype.mapPage = function(){
 	}
 
 	this.sprint(root, check);
+
+	// Check the remaining children that fit on this page
+	// to ensure the end is correctly calculated
+	if (lastChildren !== null) {
+		lastChildren.forEach(function(node){
+			if(node.nodeType == Node.TEXT_NODE &&
+			   node.textContent.trim().length) {
+				checkText(node);
+			}
+		});
+	}
 
 	// Reset back to previous RTL settings
 	if(dir == "rtl") {


### PR DESCRIPTION
This is an attempt to address the issue I described in https://github.com/futurepress/epub.js/issues/320, where the endcfi for a page incorrectly references the end of the first element on the page (rather than the last element).

The change fixes my immediate problem, but I don't understand the pagination logic well enough to know whether it is an incomplete fix, or whether it introduces other issues.

