### PR TITLE
Support vertical writing

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -309,14 +309,14 @@ EPUBJS.core.addCss = function(src, callback, target) {
 };
 
 EPUBJS.core.prefixed = function(unprefixed) {
-	var vendors = ["Webkit", "Moz", "O", "ms" ],
-		prefixes = ['-Webkit-', '-moz-', '-o-', '-ms-'],
+	var vendors = ["webkit", "Moz", "O", "ms" ],
+		prefixes = ['-webkit-', '-moz-', '-o-', '-ms-'],
 		upper = unprefixed[0].toUpperCase() + unprefixed.slice(1),
 		length = vendors.length;
 
-	if (typeof(document.documentElement.style[unprefixed]) != 'undefined') {
-		return unprefixed;
-	}
+//	if (typeof(document.documentElement.style[unprefixed]) != 'undefined') {
+//		return unprefixed;
+//	}
 
 	for ( var i=0; i < length; i++ ) {
 		if (typeof(document.documentElement.style[vendors[i] + upper]) != 'undefined') {

--- a/src/render_iframe.js
+++ b/src/render_iframe.js
@@ -160,7 +160,6 @@ EPUBJS.Render.Iframe.prototype.setPageDimensions = function(pageWidth, pageHeigh
 	this.pageWidth = pageWidth;
 	this.pageHeight = pageHeight;
     this.isVertical = isVertical;
-	this.scroll(pageWidth > this.iframe.width, pageHeight > this.iframe.height);
     this.resized();
 
 	//-- Add a page to the width of the document to account an for odd number of pages

--- a/src/render_iframe.js
+++ b/src/render_iframe.js
@@ -5,8 +5,12 @@ EPUBJS.Render.Iframe = function() {
 	this.docEl = null;
 	this.bodyEl = null;
 
-	this.leftPos = 0;
+	this.startPos = 0;
 	this.pageWidth = 0;
+	this.pageHeight = 0;
+    this.boundingWidth = 0;
+    this.boundingHeight = 0;
+	this.isVertical = false;
 };
 
 //-- Build up any html needed
@@ -51,22 +55,22 @@ EPUBJS.Render.Iframe.prototype.load = function(contents, url){
 		render.window.addEventListener("resize", render.resized.bind(render), false);
 
 		// Reset the scroll position
-		render.leftPos = 0;
-		render.setLeft(0);
+		render.startPos = 0;
+		render.setStartOffset(0);
 
 		//-- Clear Margins
 		if(render.bodyEl) {
 			render.bodyEl.style.margin = "0";
 		}
 
-		// HTML element must have direction set if RTL or columnns will
-		// not be in the correct direction in Firefox
-		// Firefox also need the html element to be position right
-		if(render.direction == "rtl" && render.docEl.dir != "rtl"){
-			render.docEl.dir = "rtl";
-			render.docEl.style.position = "absolute";
-			render.docEl.style.right = "0";
-		}
+//		// HTML element must have direction set if RTL or columnns will
+//		// not be in the correct direction in Firefox
+//		// Firefox also need the html element to be position right
+//		if(render.direction == "rtl" && render.docEl.dir != "rtl"){
+//			render.docEl.dir = "rtl";
+//			render.docEl.style.position = "absolute";
+//			render.docEl.style.right = "0";
+//		}
 
 		deferred.resolve(render.docEl);
 	};
@@ -82,14 +86,14 @@ EPUBJS.Render.Iframe.prototype.load = function(contents, url){
 	// this.iframe.contentWindow.location.replace(url);
 	this.document = this.iframe.contentDocument;
 
-  if(!this.document) {
-    deferred.reject(new Error("No Document Available"));
-    return deferred;
-  }
+    if(!this.document) {
+        deferred.reject(new Error("No Document Available"));
+        return deferred.promise;
+    }
 
-  this.document.open();
-  this.document.write(contents);
-  this.document.close();
+    this.document.open();
+    this.document.write(contents);
+    this.document.close();
 
 	return deferred.promise;
 };
@@ -125,30 +129,40 @@ EPUBJS.Render.Iframe.prototype.resize = function(width, height){
 	}
 
 	this.iframe.width = width;
-	// Get the fractional height and width of the iframe
-	// Default to orginal if bounding rect is 0
-	this.width = this.iframe.getBoundingClientRect().width || width;
-	this.height = this.iframe.getBoundingClientRect().height || height;
+//	// Get the fractional height and width of the iframe
+//	// Default to orginal if bounding rect is 0
+// 	this.width = this.iframe.getBoundingClientRect().width || width;
+// 	this.height = this.iframe.getBoundingClientRect().height || height;
 };
 
 
-EPUBJS.Render.Iframe.prototype.resized = function(e){
-	// Get the fractional height and width of the iframe
-	this.width = this.iframe.getBoundingClientRect().width;
-	this.height = this.iframe.getBoundingClientRect().height;
+EPUBJS.Render.Iframe.prototype.resized = function(){
+//	// Get the fractional height and width of the iframe
+// 	this.width = this.iframe.getBoundingClientRect().width;
+// 	this.height = this.iframe.getBoundingClientRect().height;
+    if (!this.document) return;
+    var range = this.document.createRange();
+    range.selectNodeContents(this.bodyEl);
+    var rect = range.getBoundingClientRect();
+    this.boundingWidth = rect.width;
+    this.boundingHeight = rect.height;
 };
 
 EPUBJS.Render.Iframe.prototype.totalWidth = function(){
-	return this.docEl.scrollWidth;
+    return this.boundingWidth;
 };
 
 EPUBJS.Render.Iframe.prototype.totalHeight = function(){
-	return this.docEl.scrollHeight;
+    return this.boundingHeight;
 };
 
-EPUBJS.Render.Iframe.prototype.setPageDimensions = function(pageWidth, pageHeight){
+EPUBJS.Render.Iframe.prototype.setPageDimensions = function(pageWidth, pageHeight, isVertical){
 	this.pageWidth = pageWidth;
 	this.pageHeight = pageHeight;
+    this.isVertical = isVertical;
+	this.scroll(pageWidth > this.iframe.width, pageHeight > this.iframe.height);
+    this.resized();
+
 	//-- Add a page to the width of the document to account an for odd number of pages
 	// this.docEl.style.width = this.docEl.scrollWidth + pageWidth + "px";
 };
@@ -157,24 +171,32 @@ EPUBJS.Render.Iframe.prototype.setDirection = function(direction){
 
 	this.direction = direction;
 
-	// Undo previous changes if needed
-	if(this.docEl && this.docEl.dir == "rtl"){
-		this.docEl.dir = "rtl";
-		this.docEl.style.position = "static";
-		this.docEl.style.right = "auto";
-	}
+//	// Undo previous changes if needed
+//	if(this.docEl && this.docEl.dir == "rtl"){
+//		this.docEl.dir = "rtl";
+//		this.docEl.style.position = "static";
+//		this.docEl.style.right = "auto";
+//	}
 
 };
 
-EPUBJS.Render.Iframe.prototype.setLeft = function(leftPos){
+EPUBJS.Render.Iframe.prototype.setStartOffset = function(startPos){
 	// this.bodyEl.style.marginLeft = -leftPos + "px";
 	// this.docEl.style.marginLeft = -leftPos + "px";
 	// this.docEl.style[EPUBJS.Render.Iframe.transform] = 'translate('+ (-leftPos) + 'px, 0)';
 
 	if (this.isMobile) {
-		this.docEl.style[this.transform] = 'translate('+ (-leftPos) + 'px, 0)';
+        if (this.isVertical) {
+            this.docEl.style[this.transform] = 'translate(0px, '+ (-startPos) + 'px)';
+        } else {
+            this.docEl.style[this.transform] = 'translate('+ (-startPos) + 'px, 0px)';
+        }
 	} else {
-		this.document.defaultView.scrollTo(leftPos, 0);
+        if (this.isVertical) {
+            this.document.defaultView.scrollTo(0, startPos);
+        } else {
+            this.document.defaultView.scrollTo(startPos, 0);
+        }
 	}
 
 };
@@ -206,36 +228,40 @@ EPUBJS.Render.Iframe.prototype.addHeadTag = function(tag, attrs, _doc) {
 };
 
 EPUBJS.Render.Iframe.prototype.page = function(pg){
-	this.leftPos = this.pageWidth * (pg-1); //-- pages start at 1
-
-	// Reverse for rtl langs
-	if(this.direction === "rtl"){
-		this.leftPos = this.leftPos * -1;
-	}
-
-	this.setLeft(this.leftPos);
+    //-- pages start at 1
+	if (this.isVertical) {
+        this.startPos = this.pageHeight * (pg-1);
+	} else if (this.direction === "rtl") {
+        var totalWidth = Math.ceil(this.boundingWidth / this.pageWidth) * this.pageWidth;
+        this.startPos = totalWidth - this.pageWidth * pg;
+	} else {
+        this.startPos = this.pageWidth * (pg-1);
+    }
+    this.setStartOffset(this.startPos);
 };
 
 //-- Show the page containing an Element
 EPUBJS.Render.Iframe.prototype.getPageNumberByElement = function(el){
-	var left, pg;
-	if(!el) return;
-
-	left = this.leftPos + el.getBoundingClientRect().left; //-- Calculate left offset compaired to scrolled position
-
-	pg = Math.floor(left / this.pageWidth) + 1; //-- pages start at 1
-
-	return pg;
+	if (!el) return;
+    var range = this.document.createRange();
+    range.selectNodeContents(el);
+    var rect = range.getBoundingClientRect();
+	return this.getPageNumberByRect(rect);
 };
 
 //-- Show the page containing an Element
 EPUBJS.Render.Iframe.prototype.getPageNumberByRect = function(boundingClientRect){
-	var left, pg;
-
-	left = this.leftPos + boundingClientRect.left; //-- Calculate left offset compaired to scrolled position
-	pg = Math.floor(left / this.pageWidth) + 1; //-- pages start at 1
-
-	return pg;
+    if (this.isVertical) {
+        var top = this.startPos + boundingClientRect.top;
+        return Math.floor(top / this.pageHeight) + 1;
+	} else if (this.direction === "rtl") {
+        var totalWidth = Math.ceil(this.boundingWidth / this.pageWidth) * this.pageWidth;
+        var right = totalWidth - (this.startPos + boundingClientRect.right);
+        return Math.floor(right / this.pageWidth) + 1;
+    } else {
+        var left = this.startPos + boundingClientRect.left; //-- Calculate left offset compaired to scrolled position
+        return Math.floor(left / this.pageWidth) + 1;
+    }
 };
 
 // Return the root element of the content
@@ -248,24 +274,22 @@ EPUBJS.Render.Iframe.prototype.getDocumentElement = function(){
 	return this.docEl;
 };
 
-// Checks if an element is on the screen
-EPUBJS.Render.Iframe.prototype.isElementVisible = function(el){
-	var rect;
-	var left;
-
-	if(el && typeof el.getBoundingClientRect === 'function'){
-		rect = el.getBoundingClientRect();
-		left = rect.left; //+ rect.width;
-		if( rect.width !== 0 &&
-				rect.height !== 0 && // Element not visible
-				left >= 0 &&
-				left < this.pageWidth ) {
-			return true;
-		}
-	}
-
-	return false;
-};
+//// Checks if an element is on the screen
+//EPUBJS.Render.Iframe.prototype.isElementVisible = function(el){
+//	if(el && typeof el.getBoundingClientRect === 'function'){
+//		var rect = el.getBoundingClientRect();
+//		var left = rect.left; //+ rect.width;
+//        var top = rect.top;
+//		return rect.width !== 0 &&
+//            rect.height !== 0 && // Element not visible
+//            left >= 0 &&
+//            left < this.width &&
+//            top >= 0 &&
+//            top < this.height;
+//	}
+//
+//	return false;
+//};
 
 
 EPUBJS.Render.Iframe.prototype.scroll = function(bool){

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -62,7 +62,7 @@ EPUBJS.Renderer.prototype.Events = [
 	"renderer:chapterUnloaded",
 	"renderer:chapterDisplayed",
 	"renderer:locationChanged",
-	"renderer:visibleLocationChanged",
+	"renderer:visibleRangeChanged",
 	"renderer:resized",
 	"renderer:spreads"
 ];
@@ -89,7 +89,7 @@ EPUBJS.Renderer.prototype.initialize = function(element, width, height){
 		this.render.resize('100%', '100%');
 	}
 
-	document.addEventListener("orientationchange", this.onResized);
+//	document.addEventListener("orientationchange", this.onResized);
 };
 
 /**
@@ -183,8 +183,9 @@ EPUBJS.Renderer.prototype.afterLoad = function(contents) {
 	this.doc = this.render.document;
 
 	// Format the contents using the current layout method
-	this.formated = this.layout.format(contents, this.render.width, this.render.height, this.gap);
-	this.render.setPageDimensions(this.formated.pageWidth, this.formated.pageHeight);
+	this.formated = this.layout.format(contents, this.width, this.height, this.gap);
+	this.render.setPageDimensions(this.formated.pageWidth, this.formated.pageHeight, this.formated.isVertical);
+    this.spreads = this.formated.spreads;
 
 	// window.addEventListener("orientationchange", this.onResized.bind(this), false);
 	if(!this.initWidth && !this.initHeight){
@@ -337,8 +338,9 @@ EPUBJS.Renderer.prototype.reformat = function(){
 	// Give the css styles time to update
 	// clearTimeout(this.timeoutTillCfi);
 	// this.timeoutTillCfi = setTimeout(function(){
-	renderer.formated = renderer.layout.format(renderer.render.docEl, renderer.render.width, renderer.render.height, renderer.gap);
-	renderer.render.setPageDimensions(renderer.formated.pageWidth, renderer.formated.pageHeight);
+	renderer.formated = renderer.layout.format(renderer.render.docEl, renderer.width, renderer.height, renderer.gap);
+	renderer.render.setPageDimensions(renderer.formated.pageWidth, renderer.formated.pageHeight, renderer.formated.isVertical);
+    renderer.spreads = renderer.formated.spreads;
 
 	pages = renderer.layout.calculatePages();
 	renderer.updatePages(pages);


### PR DESCRIPTION
This would not function correctly without renderer.mapPage patch. (see
my next depend pull request)

orientationchange listener is commented out because it is mostly
useless, the size is totally wrong when the event is fired, and epubjs
already listen to window.resize, which does a better job.

Vertical writing can not render in spreads layout, thus if user specify
spreads layout, the flag will be forced to false.

Some of the rtl handling is totally wrong, because setting html.dir
will force bidi which will mess up vertical-rl writing mode.

scrollWidth and element.getBoundingClientRect() are unreliable, they
give very wrong result sometimes. The only reliable measurement is to
use range.getBoundingClientRect() .

Iframe.prototype.isElementVisible is commented out because it is broken
and is not used by anyone.
