### PR TITLE
Fixed layout

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -1,5 +1,16 @@
 EPUBJS.Layout = EPUBJS.Layout || {};
 
+// EPUB2 documents won't provide us with "rendition:layout", so this is used to
+// duck type the documents instead.
+EPUBJS.Layout.isFixedLayout = function (documentElement) {
+	var viewport = documentElement.querySelector("[name=viewport]");
+	if (!viewport || !viewport.hasAttribute("content")) {
+		return false;
+	}
+	var content = viewport.getAttribute("content");
+	return /,/.test(content);
+};
+
 EPUBJS.Layout.Reflowable = function(){
 	this.documentElement = null;
 	this.spreadWidth = null;

--- a/src/layout.js
+++ b/src/layout.js
@@ -125,6 +125,8 @@ EPUBJS.Layout.Fixed = function(){
 
 EPUBJS.Layout.Fixed.prototype.format = function(documentElement, _width, _height, _gap){
 	var columnWidth = EPUBJS.core.prefixed('columnWidth');
+	var transform = EPUBJS.core.prefixed('transform');
+	var transformOrigin = EPUBJS.core.prefixed('transformOrigin');
 	var viewport = documentElement.querySelector("[name=viewport]");
 	var content;
 	var contents;
@@ -144,6 +146,17 @@ EPUBJS.Layout.Fixed.prototype.format = function(documentElement, _width, _height
 			height = contents[1].replace("height=", '');
 		}
 	}
+
+	//-- Scale fixed documents so their contents don't overflow, and
+	// vertically and horizontally center the contents
+	var widthScale = _width / width;
+	var heightScale = _height / height;
+	var scale = widthScale < heightScale ? widthScale : heightScale;
+	documentElement.style.position = "absolute";
+	documentElement.style.top = "50%";
+	documentElement.style.left = "50%";
+	documentElement.style[transform] = "scale(" + scale + ") translate(-50%, -50%)";
+	documentElement.style[transformOrigin] = "0px 0px 0px";
 
 	//-- Adjust width and height
 	documentElement.style.width =  width + "px" || "auto";

--- a/src/render_iframe.js
+++ b/src/render_iframe.js
@@ -59,15 +59,6 @@ EPUBJS.Render.Iframe.prototype.load = function(contents, url){
 			render.bodyEl.style.margin = "0";
 		}
 
-		// HTML element must have direction set if RTL or columnns will
-		// not be in the correct direction in Firefox
-		// Firefox also need the html element to be position right
-		if(render.direction == "rtl" && render.docEl.dir != "rtl"){
-			render.docEl.dir = "rtl";
-			render.docEl.style.position = "absolute";
-			render.docEl.style.right = "0";
-		}
-
 		deferred.resolve(render.docEl);
 	};
 
@@ -160,8 +151,10 @@ EPUBJS.Render.Iframe.prototype.setDirection = function(direction){
 	// Undo previous changes if needed
 	if(this.docEl && this.docEl.dir == "rtl"){
 		this.docEl.dir = "rtl";
-		this.docEl.style.position = "static";
-		this.docEl.style.right = "auto";
+		if (this.layout !== "pre-paginated") {
+			this.docEl.style.position = "static";
+			this.docEl.style.right = "auto";
+		}
 	}
 
 };
@@ -177,6 +170,10 @@ EPUBJS.Render.Iframe.prototype.setLeft = function(leftPos){
 		this.document.defaultView.scrollTo(leftPos, 0);
 	}
 
+};
+
+EPUBJS.Render.Iframe.prototype.setLayout = function (layout) {
+	this.layout = layout;
 };
 
 EPUBJS.Render.Iframe.prototype.setStyle = function(style, val, prefixed){

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -171,6 +171,19 @@ EPUBJS.Renderer.prototype.load = function(contents, url){
 			this.layoutMethod = this.determineLayout(this.layoutSettings);
 			this.layout = new EPUBJS.Layout[this.layoutMethod]();
 		}
+		this.render.setLayout(this.layoutSettings.layout);
+
+		// HTML element must have direction set if RTL or columnns will
+		// not be in the correct direction in Firefox
+		// Firefox also need the html element to be position right
+		if(this.render.direction == "rtl" && this.render.docEl.dir != "rtl"){
+			this.render.docEl.dir = "rtl";
+			if (this.render.layout !== "pre-paginated") {
+				this.render.docEl.style.position = "absolute";
+				this.render.docEl.style.right = "0";
+			}
+		}
+
 		this.afterLoad(contents);
 
 		//-- Trigger registered hooks before displaying
@@ -728,7 +741,9 @@ EPUBJS.Renderer.prototype.mapPage = function(){
 	// Set back to ltr before sprinting to get correct order
 	if(dir == "rtl") {
 		docEl.dir = "ltr";
-		docEl.style.position = "static";
+		if (this.layoutSettings.layout !== "pre-paginated") {
+			docEl.style.position = "static";
+		}
 	}
 
 	this.textSprint(root, check);
@@ -736,8 +751,10 @@ EPUBJS.Renderer.prototype.mapPage = function(){
 	// Reset back to previous RTL settings
 	if(dir == "rtl") {
 		docEl.dir = dir;
-		docEl.style.left = "auto";
-		docEl.style.right = "0";
+		if (this.layoutSettings.layout !== "pre-paginated") {
+			docEl.style.left = "auto";
+			docEl.style.right = "0";
+		}
 	}
 
 	// Check the remaining children that fit on this page

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -165,6 +165,12 @@ EPUBJS.Renderer.prototype.load = function(contents, url){
 
 	this.render.load(contents, url).then(function(contents) {
 
+		// Duck-type fixed layout books.
+		if (EPUBJS.Layout.isFixedLayout(contents)) {
+			this.layoutSettings.layout = "pre-paginated";
+			this.layoutMethod = this.determineLayout(this.layoutSettings);
+			this.layout = new EPUBJS.Layout[this.layoutMethod]();
+		}
 		this.afterLoad(contents);
 
 		//-- Trigger registered hooks before displaying


### PR DESCRIPTION
It seems Epub.js does not support fixed-sized layouts very well. I tried with the following EPUB2 document [AviationBrochure.epub](http://shareitdammit.com/YDmb2a2y) and got the following formatting:

<p align="center"><img alt="poorly formatted fixed layout epub, 1 page" src="http://shareitdammit.com/UBt2khJ3"></p>

<p align="center"><img alt="poorly formatted fixed layout epub, 2 pages" src="http://shareitdammit.com/V5od2j24"></p>

With the following changes, a single page of a fixed layout epub is rendered with the right proportions.

<p align="center"><img alt="correctly formatted fixed layout epub" src="http://shareitdammit.com/PtUiO6sz"></p>

I'll admit I'm not sure if I'm handling the right-to-left styling correctly. I made the changes in 605dd38 to fix the formatting in an Epub copy of "One-Punch Man Vol 1" (a right-to-left comic) (sorry but I'm not sure if I'm allowed to redistribute it and am having trouble finding a similar freely-redistributable document). Hopefully those changes are sufficient for fixed-size right-to-left documents.