### PR TITLE
Fix ' Cannot read property 'baseUrl' of undefined '

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -61,7 +61,7 @@ function links(view, renderer) {
       }
 
     }
-  };
+  }.bind(this);
 
   for (var i = 0; i < links.length; i++) {
     replaceLinks(links[i]);


### PR DESCRIPTION
I tried to use epub.js with angularjs and es6, and used the example i got from your docs:
```javascript
let book = ePub('./path/content.opf');
this.rendition = book.renderTo("chapter-container");
this.rendition.display();
```
I'm importing and saving `ePub` as an angular constant:

```
import ePub from 'futurepress/epub.js';

angular.module(modulename).constant('ePub', ePub);
```

and tried to move to the next page using `this.rendition.next();` and got:

```
Cannot read property 'baseUrl' of undefined TypeError: Cannot read property 'baseUrl' of undefined
   at replaceLinks (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:8991:51)
   at Rendition.links (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:9028:7)
   at http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:6438:28
   at Array.forEach (native)
   at Hook.trigger (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:6437:16)
   at Rendition.<anonymous> (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:8466:35)
   at lib$rsvp$$internal$$tryCatch (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:1306:18)
   at lib$rsvp$$internal$$invokeCallback (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:1318:19)
   at lib$rsvp$$internal$$publish (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:1289:13)
   at MutationObserver.lib$rsvp$asap$$flush (http://localhost/vendor/github/futurepress/epub.js@v0.3/dist/epub.js:1468:11)
```