### PR TITLE
add renderer before resize event, display last page on load, fix for removeChild

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -24,7 +24,8 @@ EPUBJS.Book = function(options){
 		styles : {},
 		headTags : {},
 		withCredentials: false,
-		render_method: "Iframe"
+		render_method: "Iframe",
+		displayLastPage: false
 	});
 
 	this.settings.EPUBJSVERSION = EPUBJS.VERSION;
@@ -731,7 +732,7 @@ EPUBJS.Book.prototype.startDisplay = function(){
 	}else if(this.settings.previousLocationCfi) {
 		display = this.gotoCfi(this.settings.previousLocationCfi);
 	}else{
-		display = this.displayChapter(this.spinePos);
+		display = this.displayChapter(this.spinePos, this.settings.displayLastPage);
 	}
 
 	return display;

--- a/src/render_iframe.js
+++ b/src/render_iframe.js
@@ -95,6 +95,7 @@ EPUBJS.Render.Iframe.prototype.loaded = function(v){
 	this.headEl = this.document.head;
 	this.bodyEl = this.document.body || this.document.querySelector("body");
 	this.window = this.iframe.contentWindow;
+	this.window.focus();
 
 	if(url != "about:blank"){
 		baseEl = this.iframe.contentDocument.querySelector("base");

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -65,7 +65,8 @@ EPUBJS.Renderer.prototype.Events = [
 	"renderer:visibleLocationChanged",
 	"renderer:visibleRangeChanged",
 	"renderer:resized",
-	"renderer:spreads"
+	"renderer:spreads",
+	"renderer:beforeResize"
 ];
 
 /**
@@ -1168,6 +1169,8 @@ EPUBJS.Renderer.prototype.resize = function(width, height, setSize){
 //-- Listeners for events in the frame
 
 EPUBJS.Renderer.prototype.onResized = function(e) {
+	this.trigger('renderer:beforeResize');
+	
 	var width = this.container.clientWidth;
 	var height = this.container.clientHeight;
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -400,8 +400,10 @@ EPUBJS.Renderer.prototype.remove = function() {
 		this.removeEventListeners();
 		this.removeSelectionListeners();
 	}
-
-	this.container.removeChild(this.element);
+	
+	// clean container content 
+	this.container.innerHtml = "";
+//	this.container.removeChild(this.element);
 };
 
 //-- STYLES


### PR DESCRIPTION
This is very useful when you need to display a spinner on resize.
 Exs. On mobile orientation or desktop resize with very big data epub.

It can be use with "render:resized"

example: 
``` js  
 this.book.on('renderer:beforeResize', this.loadSpinner.bind(this))
 this.book.on('renderer:resized', this.removeSpinner.bind(this));
```