### PR TITLE
fixed MS IE and Edge iframe permission error

### DIFF
--- a/src/render_iframe.js
+++ b/src/render_iframe.js
@@ -78,11 +78,11 @@ EPUBJS.Render.Iframe.prototype.load = function(contents, url){
     return deferred.promise;
   }
 
-  this.document.open();
-  this.document.write(contents);
-  this.document.close();
+  this.iframe.contentDocument.open();
+  this.iframe.contentDocument.write(contents);
+  this.iframe.contentDocument.close();
 
-	return deferred.promise;
+  return deferred.promise;
 };
 
 


### PR DESCRIPTION
This fixes the "Permission Denied" error on IE and Edge. For some reason, document.write must be done directly on the document.