### PR TITLE
Fix ToC - Changed undefined method parse.ncx to parse.toc

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -41,7 +41,7 @@ function Navigation(_package, _request){
       var loaded = loading.promise;
 
       request(navigation.ncxUrl, 'xml').then(function(xml){
-        navigation.toc = parse.ncx(xml);
+        navigation.toc = parse.toc(xml);
         navigation.loaded(navigation.toc);
         loading.resolve(navigation.toc);
       });


### PR DESCRIPTION
Fixes error: `TypeError: parse.ncx is not a function(…)`