### PR TITLE
Some books hardcode max-width on body, which breaks pagination columns

### DIFF
--- a/src/contents.js
+++ b/src/contents.js
@@ -600,6 +600,7 @@ Contents.prototype.columns = function(width, height, columnWidth, gap){
   this.css("overflowY", "hidden");
   this.css("margin", "0");
   this.css("boxSizing", "border-box");
+  this.css("maxWidth", "inherit");
 
   this.css(COLUMN_AXIS, "horizontal");
   this.css(COLUMN_FILL, "auto");


### PR DESCRIPTION
As the title says. If column-width, column-gap, width are set by the library, so it should make sure max-width is not something custom.