### PR TITLE
Book.open(url) should use the argument value if given

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -98,7 +98,7 @@ Book.prototype.open = function(_url, options){
   if (window && window.location && uri) {
     absoluteUri = uri.absoluteTo(window.location.href);
     this.url = absoluteUri.toString();
-  } if (window && window.location) {
+  } else if (window && window.location) {
     this.url = window.location.href;
   } else {
     this.url = _url;


### PR DESCRIPTION
The bug looks like introduced by a typo.