### PR TITLE
NCX files to load without pagination. 

### DIFF
--- a/src/pagelist.js
+++ b/src/pagelist.js
@@ -29,11 +29,11 @@ PageList.prototype.parse = function(xml) {
 
 	if(html) {
 		this.toc = this.parseNav(xml);
-	} else if(ncx){ // Not supported
-		// this.toc = this.parseNcx(xml);
+	} /*else if(ncx){ // Not supported
+		this.toc = this.parseNcx(xml);
 		return;
 	}
-
+*/
 };
 
 /**


### PR DESCRIPTION
Relates to enhancement: https://github.com/futurepress/epub.js/issues/507

We can have this fix till we have an enhancement to support NCX based pagination.
Currently loading of EPUBs having NCX fails due to variable "ncx" not being declared. 