### PR TITLE
Fix for https://github.com/futurepress/epub.js/issues/543

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -124,7 +124,9 @@ class Layout {
 		var formating;
 
 		if (this.name === "pre-paginated") {
-			formating = contents.fit(this.columnWidth, this.height);
+			//If it's pre-paginated no need to add any properties to content.
+			//Content should be good enough to take care of it's properties
+			return;
 		} else if (this._flow === "paginated") {
 			formating = contents.columns(this.width, this.height, this.columnWidth, this.gap);
 		} else { // scrolled

--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -69,7 +69,7 @@ class IframeView {
 
 		this.iframe = document.createElement("iframe");
 		this.iframe.id = this.id;
-		this.iframe.scrolling = "no"; // Might need to be removed: breaks ios width calculations
+		//this.iframe.scrolling = "no"; // Might need to be removed: breaks ios width calculations
 		this.iframe.style.overflow = "hidden";
 		this.iframe.seamless = "seamless";
 		// Back up if seamless isn't supported


### PR DESCRIPTION
Fix for content getting stripped in layout = 'pre-paginated' and flow = 'paginated' mode.

1.) Took of this.iframe.scrolling = "no": 
If content itself has the ability to handle scrolls, we need not restrict it at container level.
2.) Removed styles being applied to content for layout = 'pre-paginated': 
