### PR TITLE
Fixing the css rule in the hook to adjust images.

### DIFF
--- a/src/rendition.js
+++ b/src/rendition.js
@@ -598,8 +598,8 @@ class Rendition {
 
 		contents.addStylesheetRules([
 			["img",
-				["max-width", (this._layout.columnWidth) + "px; !important"],
-				["max-height", (this._layout.height) + "px; !important"],
+				["max-width", (this._layout.columnWidth) + "px !important"],
+				["max-height", (this._layout.height) + "px !important"],
 				["object-fit", "contain"],
 				["page-break-inside", "avoid"]
 			]


### PR DESCRIPTION
The semicolon breaks the "!important" part of the rule.