### PR TITLE
add settimeout in order to wait for css and images

### DIFF
--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -146,20 +146,23 @@ class IframeView {
 				// apply the layout function to the contents
 				this.settings.layout.format(this.contents);
 
-				// Expand the iframe to the full size of the content
-				this.expand();
+        setTimeout((function() {
+				  // Expand the iframe to the full size of the content
+				  this.expand();
 
-				// Listen for events that require an expansion of the iframe
-				this.addListeners();
+				  // Listen for events that require an expansion of the iframe
+				  this.addListeners();
 
-				if(show !== false) {
-					//this.q.enqueue(function(view){
-						// this.show();
-					//}, view);
-				}
-				// this.map = new Map(view, this.layout);
-				//this.hooks.show.trigger(view, this);
-				this.emit("rendered", this.section);
+				  if(show !== false) {
+				  	//this.q.enqueue(function(view){
+				  		// this.show();
+				  	//}, view);
+				  }
+				  // this.map = new Map(view, this.layout);
+				  //this.hooks.show.trigger(view, this);
+				  this.emit("rendered", this.section);
+        }).bind(this), 0);
+
 
 			}.bind(this))
 			.catch(function(e){


### PR DESCRIPTION
I have an epub with images. When loading, the reported text width (https://github.com/futurepress/epub.js/blob/v0.3/src/contents.js#L111) is not correct (In this case it is a lot bigger).

This causes an issue: to reach next html I have to run "next" several times (While I do that, a blank screen is showed)

After some digging I've found that the problem comes from a race condition between the calculation and the process of loading images and css.

A workaround that worked for me was to surround the call to "expand" (https://github.com/futurepress/epub.js/blob/v0.3/src/managers/views/iframe.js#L150) with a setTimeout in order to wait for the images and css.