### PR TITLE
Add lookup in 2nd view too

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -397,6 +397,13 @@ class DefaultViewManager {
 			view = this.views.first();
 			start = this._bounds.left - view.position().left;
 			end = start + this.layout.spreadWidth;
+      if(start >= view.bounds().width && this.views.length > 1) {
+
+        view = this.views.last();
+        start = this._bounds.left - view.position().left;
+        end = start + this.layout.spreadWidth;
+      } 
+
 			return this.mapping.page(view, view.section.cfiBase, start, end);
 		}
 


### PR DESCRIPTION
I've found that, after navigating the pages in the first view, the rendition was not reporting  locations from the second view (after the first view, the rendition was sending the same cfi).

This is the fix that worked for us.