### PR TITLE
Inject Script in Rendition, add cfiFromRange to Contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/contents.js
+++ b/src/contents.js
@@ -633,6 +633,14 @@ class Contents {
 		return cfi.toRange(this.document, ignoreClass);
 	}
 
+	cfiFromRange(range, ignoreClass){
+		return new EpubCFI(range, this.cfiBase, ignoreClass).toString();
+	}
+
+	cfiFromNode(node, ignoreClass){
+		return new EpubCFI(node, this.cfiBase, ignoreClass).toString();
+	}
+
 	map(layout){
 		var map = new Mapping(layout);
 		return map.section();

--- a/src/rendition.js
+++ b/src/rendition.js
@@ -36,7 +36,8 @@ class Rendition {
 			layout: null,
 			spread: null,
 			minSpreadWidth: 800,
-			stylesheet: null
+			stylesheet: null,
+			script: null
 		});
 
 		extend(this.settings, options);
@@ -75,6 +76,10 @@ class Rendition {
 
 		if (this.settings.stylesheet) {
 			this.book.spine.hooks.content.register(this.injectStylesheet.bind(this));
+		}
+
+		if (this.settings.script) {
+			this.book.spine.hooks.content.register(this.injectScript.bind(this));
 		}
 
 		// this.hooks.display.register(this.afterDisplay.bind(this));
@@ -636,6 +641,15 @@ class Rendition {
 		style.setAttribute("href", this.settings.stylesheet);
 		doc.getElementsByTagName("head")[0].appendChild(style);
 	}
+
+	injectScript(doc, section) {
+		let script = doc.createElement("script");
+		script.setAttribute("type", "text/javascript");
+		script.setAttribute("src", this.settings.script);
+		script.textContent = " "; // Needed to prevent self closing tag
+		doc.getElementsByTagName("head")[0].appendChild(script);
+	}
+
 }
 
 //-- Enable binding events to Renderer


### PR DESCRIPTION
Allows passing a url to be injected as javascript script tag in the serialization of the Section contents.

Also adds `cfiFromNode` & `cfiFromRange`