### PR TITLE
Remove poison CFI fix for double spineIndex

### DIFF
--- a/src/epubcfi.js
+++ b/src/epubcfi.js
@@ -948,7 +948,7 @@ class EpubCFI {
 
 	generateChapterComponent(_spineNodeIndex, _pos, id) {
 		var pos = parseInt(_pos),
-				spineNodeIndex = (_spineNodeIndex + 1) * 2,
+				spineNodeIndex = _spineNodeIndex + 1,
 				cfi = "/"+spineNodeIndex+"/";
 
 		cfi += (pos + 1) * 2;


### PR DESCRIPTION
It turns out that spineNodeIndex is set here:
this.spineNodeIndex = Array.prototype.indexOf.call(spineNode.parentNode.childNodes, spineNode);

And childNodes includes the list of all nodes (text and elements) already.