### PR TITLE
Fix spine node index in CFIs

### DIFF
--- a/src/epubcfi.js
+++ b/src/epubcfi.js
@@ -948,7 +948,7 @@ class EpubCFI {
 
 	generateChapterComponent(_spineNodeIndex, _pos, id) {
 		var pos = parseInt(_pos),
-				spineNodeIndex = _spineNodeIndex + 1,
+				spineNodeIndex = (_spineNodeIndex + 1) * 2,
 				cfi = "/"+spineNodeIndex+"/";
 
 		cfi += (pos + 1) * 2;

--- a/src/packaging.js
+++ b/src/packaging.js
@@ -52,7 +52,7 @@ class Packaging {
 		this.ncxPath = this.findNcxPath(manifestNode, spineNode);
 		this.coverPath = this.findCoverPath(packageDocument);
 
-		this.spineNodeIndex = Array.prototype.indexOf.call(spineNode.parentNode.childNodes, spineNode);
+		this.spineNodeIndex = Array.prototype.indexOf.call(spineNode.parentNode.children, spineNode);
 
 		this.spine = this.parseSpine(spineNode, this.manifest);
 

--- a/src/packaging.js
+++ b/src/packaging.js
@@ -52,7 +52,7 @@ class Packaging {
 		this.ncxPath = this.findNcxPath(manifestNode, spineNode);
 		this.coverPath = this.findCoverPath(packageDocument);
 
-    this.spineNodeIndex = indexOfElementNode(spineNode);
+		this.spineNodeIndex = indexOfElementNode(spineNode);
 
 		this.spine = this.parseSpine(spineNode, this.manifest);
 

--- a/src/packaging.js
+++ b/src/packaging.js
@@ -1,4 +1,4 @@
-import {qs, qsa, qsp} from "./utils/core";
+import {qs, qsa, qsp, indexOfElementNode} from "./utils/core";
 
 /**
  * Open Packaging Format Parser
@@ -52,7 +52,7 @@ class Packaging {
 		this.ncxPath = this.findNcxPath(manifestNode, spineNode);
 		this.coverPath = this.findCoverPath(packageDocument);
 
-		this.spineNodeIndex = Array.prototype.indexOf.call(spineNode.parentNode.children, spineNode);
+    this.spineNodeIndex = indexOfElementNode(spineNode);
 
 		this.spine = this.parseSpine(spineNode, this.manifest);
 

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -225,20 +225,28 @@ export function cleanStringForXpath(str)	{
 	return `concat(\'\',${ parts.join(",") })`;
 }
 
-export function indexOfTextNode(textNode){
-	var parent = textNode.parentNode;
+export function indexOfNode(node, typeId) {
+	var parent = node.parentNode;
 	var children = parent.childNodes;
 	var sib;
 	var index = -1;
 	for (var i = 0; i < children.length; i++) {
 		sib = children[i];
-		if(sib.nodeType === Node.TEXT_NODE){
+		if (sib.nodeType === typeId) {
 			index++;
 		}
-		if(sib == textNode) break;
+		if (sib == node) break;
 	}
 
 	return index;
+}
+
+export function indexOfTextNode(textNode) {
+	return indexOfNode(textNode, Node.TEXT_NODE);
+}
+
+export function indexOfElementNode(elementNode) {
+	return indexOfNode(elementNode, Node.ELEMENT_NODE);
 }
 
 export function isXml(ext) {


### PR DESCRIPTION
A fix is needed in two places.
1.) packaging.js -> use "children" to find only elements rather than "childNode" which can sometimes return text nodes and comment nodes, depending on the format of package.opf.
2.) epubcfi.js -> multiple the spine index by 2 to conform to CFI rules.

NOTE: The existing code works due to these two bugs canceling each other out for cases when the package.opf is formatted with spacing and no comments (and hence including two nodes for every one element in the spine).