### PR TITLE
Optional global settings to disable srcdoc, since it will fail on cordova

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -32,7 +32,8 @@ class DefaultViewManager {
 			axis: this.settings.axis,
 			layout: this.layout,
 			width: 0,
-			height: 0
+			height: 0,
+			globalOptions: extend({}, options.settings, {disableSrcdoc: options.settings.disableSrcdoc || false})
 		};
 
 	}

--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -102,7 +102,7 @@ class IframeView {
 		// Firefox has trouble with baseURI and srcdoc
 		// TODO: Disable for now in firefox
 
-		if("srcdoc" in this.iframe) {
+		if("srcdoc" in this.iframe && !this.settings.globalOptions.disableSrcdoc) {
 			this.supportsSrcdoc = true;
 		} else {
 			this.supportsSrcdoc = false;


### PR DESCRIPTION
When epubjs is used within a cordova app, srcdoc is supportet by the webview, but you would need to hack the `MainViewController.m` to enable it. And since it is considered a bad practice to store the projects platforms/* in git, it is better that we let developers disable it when initializing epubjs.

[See issue about using srcdoc in cordova here](https://issues.apache.org/jira/browse/CB-7379)