### PR TITLE
fixes for IE-11

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jszip": "^3.1.3",
     "path-webpack": "^0.0.3",
     "stream-browserify": "^2.0.1",
+    "url-api-polyfill": "^1.1.0",
     "xmldom": "^0.1.27"
   }
 }

--- a/src/epub.js
+++ b/src/epub.js
@@ -1,3 +1,4 @@
+import URL from "url-api-polyfill";
 import Book from "./book";
 import EpubCFI from "./epubcfi";
 import Rendition from "./rendition";
@@ -48,6 +49,7 @@ ePub.register = {
 ePub.register.view("iframe", require("./managers/views/iframe"));
 
 // Default View Managers
+ePub.register.manager("URL", URL);
 ePub.register.manager("default", require("./managers/default"));
 ePub.register.manager("continuous", require("./managers/continuous"));
 

--- a/src/mapping.js
+++ b/src/mapping.js
@@ -44,16 +44,17 @@ class Mapping {
 	}
 
 	walk(root, func) {
-		//var treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT + NodeFilter.SHOW_TEXT, null, false);
-		var treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-			acceptNode: function (node) {
-				if ( node.data.trim().length > 0 ) {
-					return NodeFilter.FILTER_ACCEPT;
-				} else {
-					return NodeFilter.FILTER_REJECT;
-				}
+		function acceptNode (node) {
+			if ( node.data.trim().length > 0 ) {
+				return NodeFilter.FILTER_ACCEPT;
+			} else {
+				return NodeFilter.FILTER_REJECT;
 			}
-		}, false);
+		}
+		var safeFilter = acceptNode;
+		safeFilter.acceptNode = acceptNode;
+		//var treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT + NodeFilter.SHOW_TEXT, null, false);
+		var treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, safeFilter, false);
 		var node;
 		var result;
 		while ((node = treeWalker.nextNode())) {

--- a/src/mapping.js
+++ b/src/mapping.js
@@ -44,6 +44,8 @@ class Mapping {
 	}
 
 	walk(root, func) {
+    // Work around Internet Explorer wanting a function instead of an object.
+    // IE also *requires* this argument where other browsers don't.
 		function acceptNode (node) {
 			if ( node.data.trim().length > 0 ) {
 				return NodeFilter.FILTER_ACCEPT;


### PR DESCRIPTION
Shim treeWalker and use `url-api-polyfill` for IE.

This adds IE 11 support for Windows 7, 8.1, and 10

Reference for the treeWalker fix https://github.com/webcomponents/webcomponentsjs/issues/556