### PR TITLE
Relocated event

### DIFF
--- a/examples/annotator.html
+++ b/examples/annotator.html
@@ -60,7 +60,7 @@
     rendition.on("keyup", keyListener);
     document.addEventListener("keyup", keyListener, false);
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       // console.log(location);
     });
 

--- a/examples/continuous-spreads.html
+++ b/examples/continuous-spreads.html
@@ -70,7 +70,7 @@
       console.log("selected", range);
     });
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       console.log(location);
     });
 

--- a/examples/highlights.html
+++ b/examples/highlights.html
@@ -99,7 +99,7 @@
     rendition.on("keyup", keyListener);
     document.addEventListener("keyup", keyListener, false);
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       // console.log(location);
     });
 

--- a/examples/hypothesis.html
+++ b/examples/hypothesis.html
@@ -188,7 +188,7 @@
 
   <script>
     // Load the opf
-    var book = ePub("https://s3.amazonaws.com/epubjs/books/alice/OPS/package.opf");
+    var book = ePub(window.location.protocol + "//s3.amazonaws.com/epubjs/books/alice/OPS/package.opf");
     var rendition = book.renderTo("viewer", {
       flow: "scrolled-doc",
       ignoreClass: "annotator-hl"

--- a/examples/input.html
+++ b/examples/input.html
@@ -49,7 +49,7 @@
     rendition.display();
 
     rendition.on("keyup", keyListener);
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       console.log(location);
     });
 

--- a/examples/locations.html
+++ b/examples/locations.html
@@ -69,10 +69,7 @@
 
 		rendition.on("keyup", keyListener);
 		document.addEventListener("keyup", keyListener, false);
-
-		rendition.on("locationChanged", function(location){
-      console.log(location);
-    });
+		
 
 		book.ready.then(function(){
 			// Load in stored locations from json or local storage
@@ -109,7 +106,7 @@
 						// Get the current CFI
 						var currentLocation = rendition.currentLocation();
 						// Get the Percentage (or location) from that CFI
-						var currentPage = book.locations.percentageFromCfi(currentLocation.start);
+						var currentPage = book.locations.percentageFromCfi(currentLocation.start.cfi);
 						slider.value = currentPage;
 						currentPage.value = currentPage;
 				});
@@ -122,13 +119,14 @@
 				}, false);
 
 				// Listen for location changed event, get percentage from CFI
-				rendition.on('locationChanged', function(location){
-						var percent = book.locations.percentageFromCfi(location.start);
+				rendition.on('relocated', function(location){
+						var percent = book.locations.percentageFromCfi(location.start.cfi);
 						var percentage = Math.floor(percent * 100);
 						if(!mouseDown) {
 								slider.value = percentage;
 						}
 						currentPage.value = percentage;
+						console.log(location);
 				});
 
 				// Save out the generated locations to JSON

--- a/examples/manifest.html
+++ b/examples/manifest.html
@@ -160,7 +160,7 @@
 
     });
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       var current = book.navigation.get(location.href);
 
       if (current) {

--- a/examples/marks.html
+++ b/examples/marks.html
@@ -61,7 +61,7 @@
     rendition.on("keyup", keyListener);
     document.addEventListener("keyup", keyListener, false);
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       // console.log(location);
     });
 

--- a/examples/scrolled.html
+++ b/examples/scrolled.html
@@ -38,7 +38,7 @@
       e.preventDefault();
     }, false);
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       console.log(location);
     });
 

--- a/examples/single-full.html
+++ b/examples/single-full.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>EPUB.js Scrolled Full Example</title>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.1/jszip.min.js"></script>
   <script src="../dist/epub.js"></script>
 
 
@@ -161,7 +162,7 @@
     });
     var hash = window.location.hash.slice(2);
     console.log(hash);
-    rendition.display(hash || 1);
+    rendition.display(hash || undefined);
 
 
     var next = document.getElementById("next");
@@ -215,7 +216,7 @@
       window.location.hash = "#/"+section.href
     });
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       console.log(location);
     });
 

--- a/examples/spreads.html
+++ b/examples/spreads.html
@@ -89,7 +89,7 @@
 
     });
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       console.log(location);
     });
 

--- a/examples/themes.html
+++ b/examples/themes.html
@@ -86,7 +86,7 @@
 
     });
 
-    rendition.on("locationChanged", function(location){
+    rendition.on("relocated", function(location){
       console.log(location);
     });
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -180,14 +180,28 @@ class Layout {
 	 * @return {number} spreads
 	 * @return {number} pages
 	 */
-	count(totalWidth) {
+	count(totalLength, pageLength) {
 		// var totalWidth = contents.scrollWidth();
-		var spreads = Math.ceil( totalWidth / this.delta);
+		let spreads, pages;
+
+		if (this.name === "pre-paginated") {
+			spreads = 1;
+			pages = 1;
+		} else if (this._flow === "paginated") {
+			pageLength = pageLength || this.delta;
+			spreads = Math.ceil( totalLength / pageLength);
+			pages = spreads * this.divisor;
+		} else { // scrolled
+			pageLength = pageLength || this.height;
+			spreads = Math.ceil( totalLength / pageLength);
+			pages = spreads;
+		}
 
 		return {
-			spreads : spreads,
-			pages : spreads * this.divisor
+			spreads,
+			pages
 		};
+
 	}
 }
 

--- a/src/managers/helpers/stage.js
+++ b/src/managers/helpers/stage.js
@@ -42,6 +42,7 @@ class Stage {
 		container.style.wordSpacing = "0";
 		container.style.lineHeight = "0";
 		container.style.verticalAlign = "top";
+		container.style.position = "relative";
 
 		if(axis === "horizontal") {
 			container.style.whiteSpace = "nowrap";

--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -545,8 +545,8 @@ class IframeView {
 		var targetPos = this.contents.locationOf(target, this.settings.ignoreClass);
 
 		return {
-			"left": window.scrollX + targetPos.left,
-			"top": window.scrollY + targetPos.top
+			"left": targetPos.left,
+			"top": targetPos.top
 		};
 	}
 

--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -24,8 +24,8 @@ class IframeView {
 		this.displayed = false;
 		this.rendered = false;
 
-		this.width  = this.settings.width;
-		this.height = this.settings.height;
+		// this.width  = this.settings.width;
+		// this.height = this.settings.height;
 
 		this.fixedWidth  = 0;
 		this.fixedHeight = 0;
@@ -534,6 +534,21 @@ class IframeView {
 
 		this.stopExpanding = true;
 		this.emit("hidden", this);
+	}
+
+	offset() {
+		return {
+			top: this.element.offsetTop,
+			left: this.element.offsetLeft
+		}
+	}
+
+	width() {
+		return this._width;
+	}
+
+	height() {
+		return this._height;
 	}
 
 	position() {

--- a/src/mapping.js
+++ b/src/mapping.js
@@ -169,8 +169,8 @@ class Mapping {
 					elPos = node.getBoundingClientRect();
 				}
 
-				left = this.horizontal ? elPos.left : elPos.top;
-				right = this.horizontal ? elPos.right : elPos.bottom;
+				left = Math.round(this.horizontal ? elPos.left : elPos.top);
+				right = Math.round(this.horizontal ? elPos.right : elPos.bottom);
 
 				if(left > end && $prev) {
 					return $prev;

--- a/src/rendition.js
+++ b/src/rendition.js
@@ -643,8 +643,8 @@ class Rendition {
 
 		contents.addStylesheetRules({
 			"img" : {
-				"max-width": (this._layout.columnWidth) + "px !important",
-				"max-height": (this._layout.height) + "px !important",
+				"max-width": (this._layout.columnWidth ? this._layout.columnWidth + "px" : "100%") + "!important",
+				"max-height": (this._layout.height ? this._layout.height + "px" : "50%") + "!important",
 				"object-fit": "contain",
 				"page-break-inside": "avoid"
 			}

--- a/src/spine.js
+++ b/src/spine.js
@@ -76,7 +76,6 @@ class Spine {
 					}
 					return;
 				}.bind(this);
-
 				item.next = function() {
 					let nextIndex = item.index;
 					while (nextIndex < this.spineItems.length-1) {
@@ -133,9 +132,9 @@ class Spine {
 			index = cfi.spinePos;
 		} else if(typeof target === "number" || isNaN(target) === false){
 			index = target;
-		} else if(target && target.indexOf("#") === 0) {
+		} else if(typeof target === "string" && target.indexOf("#") === 0) {
 			index = this.spineById[target.substring(1)];
-		} else if(target) {
+		} else if(typeof target === "string") {
 			// Remove fragments
 			target = target.split("#")[0];
 			index = this.spineByHref[target];
@@ -205,6 +204,30 @@ class Spine {
 	 */
 	each() {
 		return this.spineItems.forEach.apply(this.spineItems, arguments);
+	}
+
+	first() {
+		let index = 0;
+
+		while (index < this.spineItems.length-1) {
+			let next = this.get(index);
+			if (next && next.linear) {
+				return next;
+			}
+			index += 1;
+		}
+	}
+
+	last() {
+		let index = this.spineItems.length-1;
+
+		while (index > 0) {
+			let prev = this.get(index);
+			if (prev && prev.linear) {
+				return prev;
+			}
+			index -= 1;
+		}
 	}
 
 	destroy() {


### PR DESCRIPTION
Managers now return an array of all the visible sections, allowing for a new `relocated` event that reports start and end sections, cfis, locations, displayed pages, percentage and atStart / atEnd:

```javascript
{"start": {
    "index": 6,
    "href": "chapter_001.xhtml",
    "cfi": "epubcfi(/6/14[xchapter_001]!/4/2/2/2/2[c001s0000]/1:0)",
    "displayed": {
        "page": 1,
        "total": 10
    },
    "location": 1,
    "percentage": 0,
    "atStart": true
},
"end": {
    "index": 6,
    "href": "chapter_001.xhtml",
    "cfi": "epubcfi(/6/14[xchapter_001]!/4/2/10/2[c001p0004]/1:362)",
    "displayed": {
        "page": 2,
        "totalPages": 10
    },
    "location":  20,
    "percentage": 0.1
}}
```

Previous `locationChanged` event remains, but will likely be removed in future releases.