### PR TITLE
Spine, first-last methods fix

### DIFF
--- a/src/spine.js
+++ b/src/spine.js
@@ -212,25 +212,25 @@ class Spine {
 	first() {
 		let index = 0;
 
-		while (index < this.spineItems.length-1) {
+		do {
 			let next = this.get(index);
 			if (next && next.linear) {
 				return next;
 			}
 			index += 1;
-		}
+		} while (index < this.spineItems.length-1) ;
 	}
 
 	last() {
 		let index = this.spineItems.length-1;
 
-		while (index > 0) {
+		do {
 			let prev = this.get(index);
 			if (prev && prev.linear) {
 				return prev;
 			}
 			index -= 1;
-		}
+		} while (index > 0);
 	}
 
 	destroy() {


### PR DESCRIPTION
I'm keep catching this kind of errors on some of the epubs:
```
bundle.js:13001 Uncaught TypeError: Cannot read property 'index' of undefined
    at Rendition.located (bundle.js:13001)
at Rendition.reportedLocation (bundle.js:12909)
```

Which arises here:
```
if (end.index === this.book.spine.last().index && located.end.displayed.page >= located.end.displayed.total) {
located.atEnd = true;
}
```

This breaks page count functionality:  I generate locations to get total page number.

After some investigation, I found that this happens when `spineItems` array has only one item -> `while` body not evaluated -> `last()` returns `undefined`. 

This fix solves my problem.