### PR TITLE
require "jszip" in lowercase as external dependency

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
 		publicPath: "/dist/"
 	},
 	externals: {
-		"jszip": "JSZip",
+		"jszip": "jszip",
 		"xmldom": "xmldom"
 	},
 	plugins: PROD ? [


### PR DESCRIPTION
@fchasen 
#692 
Looks like the root cause for this issue is non Windows platform are case sensitive and it fails to distinguish between.
JSZip and jszip.
On looking at the epub.js (final build file) it does try to require `require("JSZip")` which is not available, rather non Windows platform fails to identify due to case mismatch.
Hence tried to change the `external` block in `webpack.config.js` to look for jszip in lowercase. This fix solves my issue.

Let know if this fix helps. 