### PR TITLE
Check if layout exists before trying to spread it

### DIFF
--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -1,7 +1,7 @@
 import {extend, defer, requestAnimationFrame} from "../../utils/core";
 import DefaultViewManager from "../default";
 import { EVENTS } from "../../utils/constants";
-import debounce from 'lodash/debounce'
+import debounce from "lodash/debounce";
 
 class ContinuousViewManager extends DefaultViewManager {
 	constructor(options) {
@@ -216,7 +216,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			return Promise.all(promises)
 				.catch((err) => {
 					updating.reject(err);
-				})
+				});
 		} else {
 			updating.resolve();
 			return updating.promise;
@@ -255,7 +255,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			if(prev) {
 				newViews.push(this.prepend(prev));
 			}
-		}
+		};
 
 		let append = () => {
 			let last = this.views.last();
@@ -265,7 +265,7 @@ class ContinuousViewManager extends DefaultViewManager {
 				newViews.push(this.append(next));
 			}
 
-		}
+		};
 
 		if (offset + visibleLength + delta >= contentLength) {
 			if (horizontal && rtl) {
@@ -545,10 +545,12 @@ class ContinuousViewManager extends DefaultViewManager {
 			this.mapping.axis(axis);
 		}
 
-		if (this.layout && axis === "vertical") {
-			this.layout.spread("none");
-		} else {
-			this.layout.spread(this.layout.settings.spread);
+		if (this.layout) {
+			if (axis === "vertical") {
+				this.layout.spread("none");
+			} else {
+				this.layout.spread(this.layout.settings.spread);
+			}
 		}
 
 		if (axis === "vertical") {

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -286,12 +286,12 @@ class DefaultViewManager {
 				displaying.resolve();
 
 			}.bind(this));
-			// .then(function(){
-			// 	return this.hooks.display.trigger(view);
-			// }.bind(this))
-			// .then(function(){
-			// 	this.views.show();
-			// }.bind(this));
+		// .then(function(){
+		// 	return this.hooks.display.trigger(view);
+		// }.bind(this))
+		// .then(function(){
+		// 	this.views.show();
+		// }.bind(this));
 		return displayed;
 	}
 
@@ -609,7 +609,7 @@ class DefaultViewManager {
 				pages,
 				totalPages,
 				mapping
-			}
+			};
 		});
 
 		return sections;
@@ -676,7 +676,7 @@ class DefaultViewManager {
 				pages,
 				totalPages,
 				mapping
-			}
+			};
 		});
 
 		return sections;
@@ -874,10 +874,12 @@ class DefaultViewManager {
 			this.mapping = new Mapping(this.layout.props, this.settings.direction, this.settings.axis);
 		}
 
-		if (this.layout && axis === "vertical") {
-			this.layout.spread("none");
-		} else {
-			this.layout.spread(this.layout.settings.spread);
+		if (this.layout) {
+			if (axis === "vertical") {
+				this.layout.spread("none");
+			} else {
+				this.layout.spread(this.layout.settings.spread);
+			}
 		}
 	}
 


### PR DESCRIPTION
f1fda8a3111b4340a50761aba89bb10f9308a010 seems to have introduced a bug where it tries to call spread on `this.layout` before it has been set. 
![image](https://user-images.githubusercontent.com/5450545/34073305-f25c709c-e296-11e7-9b08-1424d8ea0482.png)

This is reproducible by with the `continuous-scrolled.html` example.

Note: the unrelated changes are from running eslint fix on the files. If you want I can remove them for a smaller diff.