### PR TITLE
Various improvements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Epub.js
 
 Epub.js is a JavaScript library for rendering ePub documents in the browser, across many devices.
 
-Epub.js provides an interface for common ebook functions (such as rendering, persistence and pagination) without the need to develop a dedicated application or plugin. Importantly, it has an incredibly permissive [Free BSD](http://en.wikipedia.org/wiki/BSD_licenses) license.
+Epub.js provides an interface for common ebook functions (such as rendering, persistence and pagination) without the need to develop a dedicated application or plugin. Importantly, it has an incredibly permissive [FreeBSD](http://en.wikipedia.org/wiki/BSD_licenses) license.
 
 [Try it while reading Moby Dick](http://futurepress.github.com/epub.js/reader/)
 
@@ -15,11 +15,11 @@ Why EPUB
 
 ![Why EPUB](http://fchasen.com/futurepress/whyepub.png)
 
-The [EPUB standard](http://www.idpf.org/epub/30/spec/epub30-overview.html) is a widely used and easily convertible format.  Many books are currently in this format, and it is convertible to many other formats (such as PDF, Mobi and iBooks).
+The [EPUB standard](http://www.idpf.org/epub/30/spec/epub30-overview.html) is a widely used and easily convertible format. Many books are currently in this format, and it is convertible to many other formats (such as PDF, Mobi and iBooks).
 
-An unzipped ePUB3 is a collection of HTML5 files, CSS, images and other media – just like any other website.  However, it enforces a schema of book components, which allows us to render a book and its parts based on a controlled vocabulary.  
+An unzipped EPUB3 is a collection of HTML5 files, CSS, images and other media – just like any other website. However, it enforces a schema of book components, which allows us to render a book and its parts based on a controlled vocabulary.
 
-More specifically, the ePUB schema standardizes the table of contents, provides a manifest that enables the caching of the entire book, and separates the storage of the content from how it’s displayed.
+More specifically, the EPUB schema standardizes the table of contents, provides a manifest that enables the caching of the entire book, and separates the storage of the content from how it’s displayed.
 
 Getting Started
 -------------------------
@@ -30,14 +30,14 @@ Get the minified code from the build folder:
 <script src="../build/epub.min.js"></script>
 ```
 
-If you plan on using compressed (zipped) epubs (any .epub file) include the minified version of [JSZip.js](http://stuk.github.io/jszip/) which can be found in [build/libs](https://raw.githubusercontent.com/futurepress/epub.js/master/build/libs/zip.min.js)
+If you plan on using compressed (zipped) EPUBs (any .epub files), include the minified version of [JSZip.js](http://stuk.github.io/jszip/) which can be found in [build/libs](https://raw.githubusercontent.com/futurepress/epub.js/master/build/libs/zip.min.js)
 
 ```html
 <!-- Zip JS -->
 <script src="/build/libs/zip.min.js"></script>
 ```
 
-Setup a element to render to:
+Set up a element to render to:
 
 ```html
 <div onclick="Book.prevPage();">‹</div>
@@ -54,16 +54,16 @@ Create the new ePub, and then render it to that element:
 </script>
 ```
 
-See the [Documentation](./documentation/README.md) to view events and methods for getting the books contents.
+See the [Documentation](./documentation/README.md) to view events and methods for getting the book's contents.
 
 The [Examples](./examples) are likely the best place to learn how to use the library.
 
 Internet Explorer
 -------------------------
 
-Compatibility with IE is best with wicked-good-xpath, a Google-authored pure JavaScript implementation of the DOM Level 3 XPath specification (but not required). More info at https://code.google.com/p/wicked-good-xpath/
+Compatibility with IE is best with wicked-good-xpath, a Google-authored pure JavaScript implementation of the DOM Level 3 XPath specification (but not required). More info at https://github.com/google/wicked-good-xpath
 
-You can download the latest wgxpath [here](https://wicked-good-xpath.googlecode.com/svn/trunk/build/wgxpath.install.js) or from the examples folder.
+You can download the latest wgxpath [here](https://github.com/google/wicked-good-xpath/releases/tag/1.3.0) or from the examples folder.
 
 ```html
 <script src="/examples/wgxpath.install.js"></script>
@@ -82,11 +82,11 @@ EPUBJS.Hooks.register("beforeChapterDisplay").wgxpath = function(callback, rende
 wgxpath.install(window);
 ```
 
-There are currently a [number of open issues for Internet Explorer](https://github.com/futurepress/epub.js/labels/Internet%20Explorer) any help addressing them would be greatly appreciated.
+There are currently a [number of open issues for Internet Explorer](https://github.com/futurepress/epub.js/labels/Internet%20Explorer), any help addressing them would be greatly appreciated.
 
 Recent Updates
 -------------------------
-+ v2 splits the render method from the layout and renderer. Currently only iframe rendering is supported, but this change will allow for new render methods in the future. See the breaking changes to the renderer [here](https://github.com/futurepress/epub.js/blob/master/documentation/README.md#renderer).
++ v2 splits the render method from the layout and renderer. Currently only IFRAME rendering is supported, but this change will allow for new render methods in the future. See the breaking changes to the renderer [here](https://github.com/futurepress/epub.js/blob/master/documentation/README.md#renderer).
 
 + Work-in-progress pagination support using EPUB page-lists. See a [usage example](http://futurepress.github.io/epub.js/examples/pagination.html). ```renderer:pageChanged``` has changed to ```renderer:locationChanged``` and a ```book:pageChanged``` event was added to pass pagination events.
 
@@ -94,7 +94,7 @@ Recent Updates
 
 + Updated CFI handling to support text offsets. CFIs return wrapped like: ```"epubcfi(/6/12[xepigraph_001]!4/2/28/2/1:0)"```. Ranges to be added soon.
 
-+ Added support for [EPUB properties](http://www.idpf.org/epub/fxl/#property-orientation). This can be overridden in the settings and default to ```{spread: 'reflowable', layout: 'auto', orientation: 'auto'}```
++ Added support for [EPUB properties](http://www.idpf.org/epub/fxl/#property-orientation). This can be overridden in the settings and defaults to ```{spread: 'reflowable', layout: 'auto', orientation: 'auto'}```
 
 + Updated [Documentation](https://github.com/futurepress/epub.js/blob/master/documentation/README.md)
 
@@ -167,7 +167,7 @@ Hooks
 
 Similar to a plugins, Epub.js implements events that can be "hooked" into. Thus you can interact with and manipulate the contents of the book.
 
-Examples of this functionality is loading videos from YouTube links before displaying a chapters contents or implementing annotation.
+Examples of this functionality is loading videos from YouTube links before displaying a chapter's contents or implementing annotation.
 
 Hooks require a event to latch onto and a callback for when they are finished.
 


### PR DESCRIPTION
- fix license name (FreeBSD, without a space)
- wicked-good-xpath moved to GitHub, update links to it and files there
- unify capitalisation of "EPUB"
- small formatting tweaks