### PR TITLE
#755 V0.3 add options do disable orientation event programmatically

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -157,13 +157,11 @@ class DefaultViewManager {
 	}
 
 	onOrientationChange(e) {
-		if(this.optsSettings.disableOrientationEvent) {
-	    		return;
-    		}
-		
 		let {orientation} = window;
-
-		this.resize();
+		
+		if(this.optsSettings.disableOrientationEvent) {
+			this.resize();
+		}
 
 		// Per ampproject:
 		// In IOS 10.3, the measured size of an element is incorrect if the
@@ -173,7 +171,11 @@ class DefaultViewManager {
 		clearTimeout(this.orientationTimeout);
 		this.orientationTimeout = setTimeout(function(){
 			this.orientationTimeout = undefined;
-			this.resize();
+			
+			if(this.optsSettings.disableOrientationEvent) {
+				this.resize();
+			}
+			
 			this.emit(EVENTS.MANAGERS.ORIENTATION_CHANGE, orientation);
 		}.bind(this), 500);
 

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -10,6 +10,7 @@ class DefaultViewManager {
 	constructor(options) {
 
 		this.name = "default";
+		this.optsSettings = options.settings;
 		this.View = options.view;
 		this.request = options.request;
 		this.renditionQueue = options.queue;
@@ -156,6 +157,10 @@ class DefaultViewManager {
 	}
 
 	onOrientationChange(e) {
+		if(this.optsSettings.disableOrientationEvent) {
+	    		return;
+    		}
+		
 		let {orientation} = window;
 
 		this.resize();

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -159,7 +159,7 @@ class DefaultViewManager {
 	onOrientationChange(e) {
 		let {orientation} = window;
 		
-		if(this.optsSettings.disableOrientationEvent) {
+		if(this.optsSettings.resizeOnOrientationChange) {
 			this.resize();
 		}
 
@@ -172,7 +172,7 @@ class DefaultViewManager {
 		this.orientationTimeout = setTimeout(function(){
 			this.orientationTimeout = undefined;
 			
-			if(this.optsSettings.disableOrientationEvent) {
+			if(this.optsSettings.resizeOnOrientationChange) {
 				this.resize();
 			}
 			

--- a/src/rendition.js
+++ b/src/rendition.js
@@ -33,7 +33,7 @@ import ContinuousViewManager from "./managers/continuous/index";
  * @param {string} [options.spread] force spread value
  * @param {number} [options.minSpreadWidth] overridden by spread: none (never) / both (always)
  * @param {string} [options.stylesheet] url of stylesheet to be injected
- * @param {boolean} [options.disableOrientationEvent] true to disable orientation events
+ * @param {boolean} [options.resizeOnOrientationChange] false to disable orientation events
  * @param {string} [options.script] url of script to be injected
  */
 class Rendition {
@@ -50,7 +50,7 @@ class Rendition {
 			spread: null,
 			minSpreadWidth: 800,
 			stylesheet: null,
-			disableOrientationEvent: false,
+			resizeOnOrientationChange: true,
 			script: null
 		});
 

--- a/src/rendition.js
+++ b/src/rendition.js
@@ -33,6 +33,7 @@ import ContinuousViewManager from "./managers/continuous/index";
  * @param {string} [options.spread] force spread value
  * @param {number} [options.minSpreadWidth] overridden by spread: none (never) / both (always)
  * @param {string} [options.stylesheet] url of stylesheet to be injected
+ * @param {boolean} [options.disableOrientationEvent] true to disable orientation events
  * @param {string} [options.script] url of script to be injected
  */
 class Rendition {
@@ -49,6 +50,7 @@ class Rendition {
 			spread: null,
 			minSpreadWidth: 800,
 			stylesheet: null,
+			disableOrientationEvent: false,
 			script: null
 		});
 


### PR DESCRIPTION
add options to disable orientation event if user needs. this is safe for users that do not need it. This can be useful for some complex fixed layout epub on ios and mobile that need a custom methods.