### PR TITLE
Floor width from getBoundingClientRect

### DIFF
--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -245,7 +245,7 @@ class ContinuousViewManager extends DefaultViewManager {
 		let dir = horizontal && rtl ? -1 : 1; //RTL reverses scrollTop
 
 		var offset = horizontal ? this.scrollLeft : this.scrollTop * dir;
-		var visibleLength = horizontal ? bounds.width : bounds.height;
+		var visibleLength = horizontal ? Math.floor(bounds.width) : bounds.height;
 		var contentLength = horizontal ? this.container.scrollWidth : this.container.scrollHeight;
 
 		let prepend = () => {
@@ -356,7 +356,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			if(this.settings.axis === "vertical") {
 				this.scrollTo(0, prevTop - bounds.height, true);
 			} else {
-				this.scrollTo(prevLeft - bounds.width, 0, true);
+				this.scrollTo(prevLeft - Math.floor(bounds.width), 0, true);
 			}
 		}
 

--- a/src/managers/helpers/stage.js
+++ b/src/managers/helpers/stage.js
@@ -159,8 +159,8 @@ class Stage {
 			bounds = this.element.getBoundingClientRect();
 
 			if(bounds.width) {
-				width = bounds.width;
-				this.container.style.width = bounds.width + "px";
+				width = Math.floor(bounds.width);
+				this.container.style.width = width + "px";
 			}
 		}
 
@@ -176,7 +176,7 @@ class Stage {
 
 		if(!isNumber(width)) {
 			bounds = this.container.getBoundingClientRect();
-			width = bounds.width;
+			width = Math.floor(bounds.width);
 			//height = bounds.height;
 		}
 


### PR DESCRIPTION
Width from bounds can be a double. For example 701.5.
The .5 will result in incorrect page change in next() since container.scrollWidth is a whole number.
Meaning it will go to next section skipping the last page in current section.