### PR TITLE
Fix toc loading with json

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -303,11 +303,9 @@ class Navigation {
 	 * @param  {object} json the items to be loaded
 	 */
 	load(json) {
-		return json.map((item) => {
+		return json.map(item => {
 			item.label = item.title;
-			if (item.children) {
-				item.subitems = this.load(item.children);
-			}
+			item.subitems = item.children ? this.load(item.children) : [];
 			return item;
 		});
 	}


### PR DESCRIPTION
I'm trying to open a book with its json manifest url.
It fails when loading the toc because some items don't have subitems.