### PR TITLE
Fix jszip module path

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,9 +6,12 @@ import minify from 'rollup-plugin-babel-minify';
 
 import pkg from './package.json';
 
+const path = require('path');
+
 const plugins = [
 	alias({
-		path: 'path-webpack'
+		path: 'path-webpack',
+        jszip: path.resolve("./node_modules/jszip/dist/jszip")
 	}),
 	resolve(),
 	commonjs()

--- a/src/epub/archive.js
+++ b/src/epub/archive.js
@@ -2,7 +2,7 @@ import {defer, isXml, parse} from "../utils/core";
 import request from "../utils/request";
 import mime from "../../libs/mime/mime";
 import Path from "../utils/path";
-import JSZip from "jszip/dist/jszip";
+import JSZip from "jszip";
 
 /**
  * Handles Unzipping a requesting files from an Epub Archive

--- a/src/workers/epub.worker.js
+++ b/src/workers/epub.worker.js
@@ -1,6 +1,6 @@
 import Epub from "../epub/epub";
 import { EVENTS } from "../utils/constants";
-import JSZip from "jszip/dist/jszip";
+import JSZip from "jszip";
 import mime from "../../libs/mime/mime";
 
 const DEV = false;


### PR DESCRIPTION
JSZip lib was exported to the `dist/epub.js` file (on the v0.4 version).
It was marked as external so I thought it was not correct.

I fixed it by setting an alias for the jszip module.