### PR TITLE
Fix json resources typo on json manifest load

### DIFF
--- a/src/epub/packaging.js
+++ b/src/epub/packaging.js
@@ -305,7 +305,7 @@ class Packaging {
 			return item;
 		});
 
-		if (json.resource) {
+		if (json.resources) {
 			json.resources.forEach((item) => {
 				let id = item.id || item.href;
 


### PR DESCRIPTION
It's just a typo fix but it was preventing the load of the `manifest.json`.