### PR TITLE
Set esversion to 6 for JSHint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,6 @@
 {
+  "esversion": 6,
+
   "browser": true,
   "devel": true,
   "worker": true,


### PR DESCRIPTION
I don't know if JSHint is still used on the project but I set the ES version to 6.