### PR TITLE
Fixes for Internet Explorer

### DIFF
--- a/src/section.js
+++ b/src/section.js
@@ -95,7 +95,7 @@ class Section {
 				var isIE = userAgent.indexOf('Trident') >= 0;
 				var Serializer;
 				if (typeof XMLSerializer === "undefined" || isIE) {
-					Serializer = require("xmldom").XMLSerializer;
+					Serializer = require("xmldom/dom-parser").XMLSerializer;
 				} else {
 					Serializer = XMLSerializer;
 				}

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,4 +1,5 @@
 import path from "path-webpack";
+import URL from "../../libs/url/url-polyfill";
 
 /**
  * Creates a Path object for parsing and manipulation of a path strings


### PR DESCRIPTION
Have to update libs/url/url-polyfill.js to the latest version, because it threw error "Object doesn't support this action" on ie11.

I import XMLSerializer from "xmldom/dom-parser", because "xmldom" returns undefined.

UPD: libs/url/url-polyfill.js was restored