### PR TITLE
Use querySelector instead of getElementById on manifest node

### DIFF
--- a/src/packaging.js
+++ b/src/packaging.js
@@ -214,7 +214,7 @@ class Packaging {
 			tocId = spineNode.getAttribute("toc");
 			if(tocId) {
 				// node = manifestNode.querySelector("item[id='" + tocId + "']");
-				node = manifestNode.getElementById(tocId);
+				node = manifestNode.querySelector(`#${tocId}`);
 			}
 		}
 


### PR DESCRIPTION
`getElementById` is a Document method. So instead, use `querySelector` on the manifest node. Thanks for this awesome project. :1st_place_medal: 