### PR TITLE
Navigation href fallback for parent detection

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -162,6 +162,10 @@ class Navigation {
 		}
 
 		let src = content.getAttribute("href") || "";
+		
+		if (!id) {
+			id = src;
+		}
 		let text = content.textContent || "";
 		let subitems = [];
 		let parentItem = getParentByTagName(item, "li");
@@ -169,12 +173,20 @@ class Navigation {
 
 		if (parentItem) {
 			parent = parentItem.getAttribute("id");
+			if (!parent) {
+				const parentContent = filterChildren(parentItem, "a", true);
+				parent = parentContent && parentContent.getAttribute("href");
+      			}
 		}
 
 		while (!parent && parentItem) {
 			parentItem = getParentByTagName(parentItem, "li");
 			if (parentItem) {
 				parent = parentItem.getAttribute("id");
+				if (!parent) {
+					const parentContent = filterChildren(parentItem, "a", true);
+          				parent = parentContent && parentContent.getAttribute("href");
+        			}
 			}
 		}
 


### PR DESCRIPTION
The navItem function assumes that every item has an id attribute.
In practice this is not always the case, this will use the href attribute as fallback for the id attribute.