### PR TITLE
correct documentation for compare method

### DIFF
--- a/documentation/md/API.md
+++ b/documentation/md/API.md
@@ -1451,7 +1451,7 @@ Compare which of two CFIs is earlier in the text
 -   `cfiOne`  
 -   `cfiTwo`  
 
-Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** First is earlier = 1, Second is earlier = -1, They are equal = 0
+Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** First is earlier = -1, Second is earlier = 1, They are equal = 0
 
 ### fromRange
 

--- a/src/epubcfi.js
+++ b/src/epubcfi.js
@@ -332,7 +332,7 @@ class EpubCFI {
 
 	/**
 	 * Compare which of two CFIs is earlier in the text
-	 * @returns {number} First is earlier = 1, Second is earlier = -1, They are equal = 0
+	 * @returns {number} First is earlier = -1, Second is earlier = 1, They are equal = 0
 	 */
 	compare(cfiOne, cfiTwo) {
 		var stepsA, stepsB;


### PR DESCRIPTION
The documentation for epubcfi.compare() states:

> Returns number First is earlier = 1, Second is earlier = -1, They are equal = 0

However it does the opposite, as described in this issue: https://github.com/futurepress/epub.js/issues/841

This is analagous to normal javascript sort() compare function behavior.

This PR corrects the documentation to reflect this, e.g. 

> Returns number First is earlier = -1, Second is earlier = 1, They are equal = 0