### PR TITLE
Parse nxcItem with namespace

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -296,7 +296,7 @@ class Navigation {
 				parentNode = item.parentNode,
 				parent;
 
-		if(parentNode && parentNode.nodeName === "navPoint") {
+		if(parentNode && (parentNode.nodeName === "navPoint" || parentNode.nodeName.split(':').slice(-1)[0] === "navPoint")) {
 			parent = parentNode.getAttribute("id");
 		}
 


### PR DESCRIPTION
Some Ncx files have a namespace. A normal navpoint looks like this:

    
    <navPoint id="id3" playOrder="3">
    

But a namespaced navPoint looks like this:

    
    <ncx:navPoint id="id3" playOrder="3">
    

This change will remove the namespace  of the nodeName. This way we'll get a properly nested TOC.