### PR TITLE
Catch exceptions when parsing links

### DIFF
--- a/src/utils/replacements.js
+++ b/src/utils/replacements.js
@@ -90,13 +90,19 @@ export function replaceLinks(contents, fn) {
 		}
 
 		var absolute = (href.indexOf("://") > -1);
-		var linkUrl = new Url(href, location);
 
 		if(absolute){
 
 			link.setAttribute("target", "_blank");
 
 		}else{
+			var linkUrl;
+			try {
+				linkUrl = new Url(href, location);	
+			} catch(error) {
+				// NOOP
+			}
+
 			link.onclick = function(){
 
 				if(linkUrl && linkUrl.hash) {


### PR DESCRIPTION
`replaceLinks` will break if a section contains a link like `http://web.archive.org/web/20060302215711/http://cantor.english.uga.edu/docs/pattern`.

* avoids creating `linkUrl` for absolute URLs
* leaves `linkURL` undefined on exception
