### PR TITLE
Implement serialized themes CSS

### DIFF
--- a/src/contents.js
+++ b/src/contents.js
@@ -676,9 +676,11 @@ class Contents {
 		}.bind(this));
 	}
 
-	_getStylesheetNode() {
+	_getStylesheetNode(key) {
 		var styleEl;
-		var key = "epubjs-inserted-css";
+		key = "epubjs-inserted-css-" + (key || '');
+
+		if(!this.document) return false;
 		
 		// Check if link already exists
 		styleEl = this.document.getElementById(key);
@@ -694,11 +696,16 @@ class Contents {
 	/**
 	 * Append stylesheet css
 	 * @param {string} serializedCss 
+	 * @param {string} key If the key is the same, the CSS will be replaced instead of inserted
 	 */
-	addStylesheetSerialized(serializedCss) {
+	addStylesheetCss(serializedCss, key) {
+		if(!this.document || !serializedCss) return false;
+
 		var styleEl;
-		styleEl = this._getStylesheetNode();
-		styleEl.innerText = serializedCss;
+		styleEl = this._getStylesheetNode(key);
+		styleEl.innerHTML = serializedCss;
+		
+		return true;
 	}
 
 	/**
@@ -706,14 +713,15 @@ class Contents {
 	 * Array: https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule
 	 * Object: https://github.com/desirable-objects/json-to-css
 	 * @param {array | object} rules
+	 * @param {string} key If the key is the same, the CSS will be replaced instead of inserted
 	 */
-	addStylesheetRules(rules) {
+	addStylesheetRules(rules, key) {
 		var styleSheet;
 
 		if(!this.document || !rules || rules.length === 0) return;
 
 		// Grab style sheet
-		styleSheet = this._getStylesheetNode().sheet;
+		styleSheet = this._getStylesheetNode(key).sheet;
 
 		if (Object.prototype.toString.call(rules) === "[object Array]") {
 			for (var i = 0, rl = rules.length; i < rl; i++) {

--- a/src/contents.js
+++ b/src/contents.js
@@ -681,7 +681,7 @@ class Contents {
 		var key = "epubjs-inserted-css";
 		
 		// Check if link already exists
-		styleEl = this.document.getElementById("#"+key);
+		styleEl = this.document.getElementById(key);
 		if (!styleEl) {
 			styleEl = this.document.createElement("style");
 			styleEl.id = key;
@@ -708,15 +708,12 @@ class Contents {
 	 * @param {array | object} rules
 	 */
 	addStylesheetRules(rules) {
-		var styleEl;
 		var styleSheet;
 
 		if(!this.document || !rules || rules.length === 0) return;
 
-		styleEl = this._getStylesheetNode();
-
 		// Grab style sheet
-		styleSheet = styleEl.sheet;
+		styleSheet = this._getStylesheetNode().sheet;
 
 		if (Object.prototype.toString.call(rules) === "[object Array]") {
 			for (var i = 0, rl = rules.length; i < rl; i++) {

--- a/src/contents.js
+++ b/src/contents.js
@@ -676,6 +676,31 @@ class Contents {
 		}.bind(this));
 	}
 
+	_getStylesheetNode() {
+		var styleEl;
+		var key = "epubjs-inserted-css";
+		
+		// Check if link already exists
+		styleEl = this.document.getElementById("#"+key);
+		if (!styleEl) {
+			styleEl = this.document.createElement("style");
+			styleEl.id = key;
+			// Append style element to head
+			this.document.head.appendChild(styleEl);
+		}
+		return styleEl;
+	}
+
+	/**
+	 * Append stylesheet css
+	 * @param {string} serializedCss 
+	 */
+	addStylesheetSerialized(serializedCss) {
+		var styleEl;
+		styleEl = this._getStylesheetNode();
+		styleEl.innerText = serializedCss;
+	}
+
 	/**
 	 * Append stylesheet rules to a generate stylesheet
 	 * Array: https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule
@@ -685,19 +710,10 @@ class Contents {
 	addStylesheetRules(rules) {
 		var styleEl;
 		var styleSheet;
-		var key = "epubjs-inserted-css";
 
 		if(!this.document || !rules || rules.length === 0) return;
 
-		// Check if link already exists
-		styleEl = this.document.getElementById("#"+key);
-		if (!styleEl) {
-			styleEl = this.document.createElement("style");
-			styleEl.id = key;
-		}
-
-		// Append style element to head
-		this.document.head.appendChild(styleEl);
+		styleEl = this._getStylesheetNode();
 
 		// Grab style sheet
 		styleSheet = styleEl.sheet;

--- a/src/themes.js
+++ b/src/themes.js
@@ -83,6 +83,18 @@ class Themes {
 	}
 
 	/**
+	 * Register a theme by passing its css as string
+	 * @param {string} name 
+	 * @param {string} css 
+	 */
+	registerCss (name, css) {
+		this._themes[name] = { "serialized" : css };
+		if (this._injected[name]) {
+			this.update(name);
+		}
+	}
+
+	/**
 	 * Register a url
 	 * @param {string} name
 	 * @param {string} input
@@ -176,7 +188,7 @@ class Themes {
 		if (theme.url) {
 			contents.addStylesheet(theme.url);
 		} else if (theme.serialized) {
-			// TODO: handle serialized
+			contents.addStylesheetSerialized(theme.serialized);
 		} else if (theme.rules) {
 			contents.addStylesheetRules(theme.rules);
 			theme.injected = true;

--- a/src/themes.js
+++ b/src/themes.js
@@ -188,9 +188,10 @@ class Themes {
 		if (theme.url) {
 			contents.addStylesheet(theme.url);
 		} else if (theme.serialized) {
-			contents.addStylesheetSerialized(theme.serialized);
+			contents.addStylesheetCss(theme.serialized, name);
+			theme.injected = true;
 		} else if (theme.rules) {
-			contents.addStylesheetRules(theme.rules);
+			contents.addStylesheetRules(theme.rules, name);
 			theme.injected = true;
 		}
 	}

--- a/src/themes.js
+++ b/src/themes.js
@@ -89,7 +89,7 @@ class Themes {
 	 */
 	registerCss (name, css) {
 		this._themes[name] = { "serialized" : css };
-		if (this._injected[name]) {
+		if (this._injected[name] || name == 'default') {
 			this.update(name);
 		}
 	}
@@ -102,7 +102,7 @@ class Themes {
 	registerUrl (name, input) {
 		var url = new Url(input);
 		this._themes[name] = { "url": url.toString() };
-		if (this._injected[name]) {
+		if (this._injected[name] || name == 'default') {
 			this.update(name);
 		}
 	}
@@ -115,7 +115,7 @@ class Themes {
 	registerRules (name, rules) {
 		this._themes[name] = { "rules": rules };
 		// TODO: serialize css rules
-		if (this._injected[name]) {
+		if (this._injected[name] || name == 'default') {
 			this.update(name);
 		}
 	}

--- a/types/contents.d.ts
+++ b/types/contents.d.ts
@@ -28,7 +28,9 @@ export default class Contents {
 
     addStylesheet(src: string): Promise<boolean>;
 
-    addStylesheetRules(rules: Array<object> | object): Promise<boolean>;
+    addStylesheetRules(rules: Array<object> | object, key: string): Promise<boolean>;
+
+    addStylesheetCss(serializedCss: string, key: string): Promise<boolean>;
 
     cfiFromNode(node: Node, ignoreClass?: string): string;
 

--- a/types/themes.d.ts
+++ b/types/themes.d.ts
@@ -14,6 +14,8 @@ export default class Themes {
 
   registerThemes( themes: object ): void;
 
+  registerCss( name: string, css: string ): void;
+
   registerUrl( name: string, input: string ): void;
 
   registerRules( name: string, rules: object ): void;


### PR DESCRIPTION
I have seen you started implementing this ... This is adding a method `registerCss(name, css)` in order to pass raw CSS. Not sure how to adapt the sugar methods `default`, `registerThemes`, `register`, though, as both the URL and the CSS are strings. Intelligentily detecting "://" maybe?