### PR TITLE
Fix vender prefixing

### DIFF
--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -93,16 +93,16 @@ export function isFloat(n) {
 export function prefixed(unprefixed) {
 	var vendors = ["Webkit", "webkit", "Moz", "O", "ms" ];
 	var prefixes = ["-webkit-", "-webkit-", "-moz-", "-o-", "-ms-"];
-	var upper = unprefixed[0].toUpperCase() + unprefixed.slice(1);
+	var lower = unprefixed.toLowerCase();
 	var length = vendors.length;
 
-	if (typeof(document) === "undefined" || typeof(document.body.style[unprefixed]) != "undefined") {
+	if (typeof(document) === "undefined" || typeof(document.body.style[lower]) != "undefined") {
 		return unprefixed;
 	}
 
-	for ( var i=0; i < length; i++ ) {
-		if (typeof(document.body.style[vendors[i] + upper]) != "undefined") {
-			return prefixes[i] + unprefixed;
+	for (var i = 0; i < length; i++) {
+		if (typeof(document.body.style[prefixes[i] + lower]) != "undefined") {
+			return prefixes[i] + lower;
 		}
 	}
 


### PR DESCRIPTION
Did not detect vender prefix on old Android browser (before Chrome).
Prefixed return value was also wrong.

Does any browser actually require the css prop to begin with an uppercased char for this to work?