### PR TITLE
Feature: Added NCX support for pageList

### DIFF
--- a/src/pagelist.js
+++ b/src/pagelist.js
@@ -75,30 +75,43 @@ class PageList {
 	}
 
 	parseNcx(navXml) {
-		const pageList = qs(navXml, 'pageList');
-		if (!pageList) return [];
+		var list = [];
+		var i = 0;
+		var item;
+		var pageList;
+		var pageTargets;
+		var length = 0;
 
-		const pageTargets = qsa(pageList, 'pageTarget');
+		pageList = qs(navXml, "pageList");
+		if (!pageList) return list;
+
+		pageTargets = qsa(pageList, "pageTarget");
+		length = pageTargets.length;
 
 		if (!pageTargets || pageTargets.length === 0) {
-			return [];
+			return list;
 		}
 
-		return [...pageTargets].map(x => this.ncxItem(x));
+		for (i = 0; i < length; ++i) {
+			item = this.ncxItem(pageTargets[i]);
+			list.push(item);
+		}
+
+		return list;
 	}
 
 	ncxItem(item) {
-		const navLabel = qs(item, 'navLabel');
-		const navLabelText = qs(navLabel, 'text');
-		const pageText = navLabelText.textContent;
-		const content = qs(item, 'content');
+		var navLabel = qs(item, "navLabel");
+		var navLabelText = qs(navLabel, "text");
+		var pageText = navLabelText.textContent;
+		var content = qs(item, "content");
 
-		const href = content.getAttribute('src');
-		const page = parseInt(pageText, 10);
+		var href = content.getAttribute("src");
+		var page = parseInt(pageText, 10);
 
 		return {
-			href,
-			page,
+			"href": href,
+			"page": page,
 		};
 	}
 

--- a/src/pagelist.js
+++ b/src/pagelist.js
@@ -45,7 +45,6 @@ class PageList {
 			return this.parseNav(xml);
 		} else if(ncx){
 			return this.parseNcx(xml);
-			return;
 		}
 
 	}

--- a/src/pagelist.js
+++ b/src/pagelist.js
@@ -43,8 +43,8 @@ class PageList {
 
 		if(html) {
 			return this.parseNav(xml);
-		} else if(ncx){ // Not supported
-			// return this.parseNcx(xml);
+		} else if(ncx){
+			return this.parseNcx(xml);
 			return;
 		}
 
@@ -72,6 +72,34 @@ class PageList {
 		}
 
 		return list;
+	}
+
+	parseNcx(navXml) {
+		const pageList = qs(navXml, 'pageList');
+		if (!pageList) return [];
+
+		const pageTargets = qsa(pageList, 'pageTarget');
+
+		if (!pageTargets || pageTargets.length === 0) {
+			return [];
+		}
+
+		return [...pageTargets].map(x => this.ncxItem(x));
+	}
+
+	ncxItem(item) {
+		const navLabel = qs(item, 'navLabel');
+		const navLabelText = qs(navLabel, 'text');
+		const pageText = navLabelText.textContent;
+		const content = qs(item, 'content');
+
+		const href = content.getAttribute('src');
+		const page = parseInt(pageText, 10);
+
+		return {
+			href,
+			page,
+		};
 	}
 
 	/**


### PR DESCRIPTION
This pull request contains some changes that allow epub.js to parse the pageList from a NCX file.

**Side notes:**

- The pageList assumes that pages are numeric. This not true, roman numerals are sometimes used for pages before the main content, alphabetic symbols are sometimes used for the appendix.

- The loading/loaded promise in book.js resolves the pageList at the wrong time. Maybe it's better to resolve the promise at the same time the `navigation` resolves.

