### PR TITLE
Added removeOverride() in rendition.themes to remove a css property in rendition.themes._overrides

### DIFF
--- a/src/contents.js
+++ b/src/contents.js
@@ -261,6 +261,8 @@ class Contents {
 
 		if (value) {
 			content.style.setProperty(property, value, priority ? "important" : "");
+		} else {
+			content.style.removeProperty(property);
 		}
 
 		return this.window.getComputedStyle(content)[property];

--- a/src/themes.js
+++ b/src/themes.js
@@ -202,6 +202,16 @@ class Themes {
 		});
 	}
 
+	removeOverride (name) {
+		var contents = this.rendition.getContents();
+
+		delete this._overrides[name];
+
+		contents.forEach( (content) => {
+			content.css(name);
+		});
+	}
+
 	/**
 	 * Add all overrides
 	 * @param {Content} content


### PR DESCRIPTION
There are some instances that I want to remove and override a css property I have added using rendition.themes.override() and I can't seem to find a default method in epubjs to do this, so I added one. Maybe this will help some people too.

Usage:
`rendition.themes.removeOverride(cssProperty)`