### PR TITLE
Bypass iframe dynamic html security for Cordova windows platform, Fix for #991

### DIFF
--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -381,7 +381,15 @@ class IframeView {
 			}
 
 			this.iframe.contentDocument.open();
-			this.iframe.contentDocument.write(contents);
+			// For Cordova windows platform
+			if(window.MSApp && MSApp.execUnsafeLocalFunction) {
+				var outerThis = this;
+				MSApp.execUnsafeLocalFunction(function () {
+					outerThis.iframe.contentDocument.write(contents);
+				});
+			} else {
+				this.iframe.contentDocument.write(contents);
+			}
 			this.iframe.contentDocument.close();
 
 		}


### PR DESCRIPTION
This fixes the issue https://github.com/futurepress/epub.js/issues/991
inspired from https://github.com/microsoft/winstore-jscompat/blob/master/winstore-jscompat.js