### PR TITLE
Fix the parent type of NavItem interface (NavItem -> string)

### DIFF
--- a/types/navigation.d.ts
+++ b/types/navigation.d.ts
@@ -3,7 +3,7 @@ export interface NavItem {
   href: string,
   label: string,
   subitems?: Array<NavItem>,
-  parent?: NavItem
+  parent?: string
 }
 
 export interface LandmarkItem {


### PR DESCRIPTION
The `parent` in `NavItem` interface should be element's `id` or `href`, which is `string` type, not `NavItem`.
```js
// Source code in navigation.js:
if (parentItem) {
	parent = parentItem.getAttribute("id");
	if (!parent) {
		const parentContent = filterChildren(parentItem, "a", true);
		parent = parentContent && parentContent.getAttribute("href");
      	}
}
```