### PR TITLE
Ignore url search string when determining INPUT_TYPE

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -423,6 +423,11 @@ class Book {
 		path = url.path();
 		extension = path.extension;
 
+		// If there's a search string, remove it before determining type
+		if (extension) {
+			extension = extension.replace(/\?.*$/, "");
+		}
+
 		if (!extension) {
 			return INPUT_TYPE.DIRECTORY;
 		}


### PR DESCRIPTION
When epub URLs have search strings they mess up Book.determineType. If, for example, the epub URL is http://some.org/some.epub?param=value, the path extension should be "epub" not "epub?param=value". The correct INPUT_TYPE for that URL should be INPUT_TYPE.EPUB.