### PR TITLE
Map over display function instead of displayed value.

### DIFF
--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -283,7 +283,7 @@ class ContinuousViewManager extends DefaultViewManager {
 		}
 
 		let promises = newViews.map((view) => {
-			return view.displayed;
+			return view.display(this.request);
 		});
 
 		if(newViews.length){


### PR DESCRIPTION
Previously we were mapping over the displayed status boolean and
treating it like a promise when it wasn't one. I assume we meant to
instead call the display function. I discovered this because I saw on mobile the relocated event wasn't being called when navigating to a chapter that had not yet been loaded. This fixes that issues and makes the relocated event always be called on chapter change.