### PR TITLE
Fix broken coverUrl for archived Epubs

### DIFF
--- a/documentation/md/API.md
+++ b/documentation/md/API.md
@@ -136,7 +136,7 @@ Set headers request should use
 
 Get the cover url
 
-Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** coverUrl
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** Promise resolves with url string
 
 ### getRange
 

--- a/src/book.js
+++ b/src/book.js
@@ -660,14 +660,13 @@ class Book {
 
 	/**
 	 * Get the cover url
-	 * @return {string} coverUrl
+	 * @return {Promise<string>} coverUrl
 	 */
 	coverUrl() {
 		var retrieved = this.loaded.cover.
 			then((url) => {
 				if(this.archived) {
-					// return this.archive.createUrl(this.cover);
-					return this.resources.get(this.cover);
+					return this.archive.createUrl(this.cover);
 				}else{
 					return this.cover;
 				}

--- a/test/book.js
+++ b/test/book.js
@@ -1,11 +1,32 @@
 var assert = require('assert');
+
 describe('Book', function() {
 
 	var Book = require('../src/book');
 
-	before(function(){
-
+	describe('Unarchived', function() {
+		var book = new Book("/fixtures/alice/OPS/package.opf");
+		it('should open a epub', async function() {
+			await book.opened
+			assert.equal(book.isOpen, true, "book is opened");
+			assert.equal( book.url.toString(), "http://localhost:9876/fixtures/alice/OPS/package.opf", "book url is passed to new Book" );
+		});
+		it('should have a local coverUrl', async function() {
+			assert.equal( await book.coverUrl(), "http://localhost:9876/fixtures/alice/OPS/images/cover_th.jpg", "cover url is available" );
+		});
 	});
 
+	describe('Archived epub', function() {
+		var book = new Book("/fixtures/alice.epub");
 
-})
+		it('should open a archived epub', async function() {
+			await book.opened
+			assert.equal(book.isOpen, true, "book is opened");
+			assert(book.archive, "book is unarchived");
+		});
+		it('should have a blob coverUrl', async function() {
+			let coverUrl = await book.coverUrl()
+			assert( /^blob:http:\/\/localhost:9876\/[^\/]+$/.test(coverUrl), "cover url is available and a blob: url" );
+		});
+	});
+});

--- a/types/book.d.ts
+++ b/types/book.d.ts
@@ -65,7 +65,7 @@ export default class Book {
 
     canonical(path: string): string;
 
-    coverUrl(): string;
+    coverUrl(): Promise<string>;
 
     destroy(): void;
 


### PR DESCRIPTION
When calling coverUrl for an archived epub the resolved promise contains
undefined and not a string.

Also the documentation everywhere is lying about coverUrl() returning a
string whereas it actually returns a Promise that resolves to a string.