### PR TITLE
Fix opening an ArrayBuffer without options

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -52,7 +52,8 @@ class Book {
 		// Allow passing just options to the Book
 		if (typeof(options) === "undefined" &&
 			  typeof(url) !== "string" &&
-		    url instanceof Blob === false) {
+		    url instanceof Blob === false &&
+		    url instanceof ArrayBuffer === false) {
 			options = url;
 			url = undefined;
 		}

--- a/test/book.js
+++ b/test/book.js
@@ -29,4 +29,25 @@ describe('Book', function() {
 			assert( /^blob:http:\/\/localhost:9876\/[^\/]+$/.test(coverUrl), "cover url is available and a blob: url" );
 		});
 	});
+
+	describe('Archived epub in array buffer without options', function() {
+		let book;
+
+		before(async function() {
+			const response = await fetch("/fixtures/alice.epub");
+			const buffer = await response.arrayBuffer()
+			book = new Book(buffer)
+		})
+
+		it('should open a archived epub', async function() {
+			await book.opened
+			assert.equal(book.isOpen, true, "book is opened");
+			assert(book.archive, "book is unarchived");
+		});
+
+		it('should have a blob coverUrl', async function() {
+			let coverUrl = await book.coverUrl()
+			assert( /^blob:http:\/\/localhost:9876\/[^\/]+$/.test(coverUrl), "cover url is available and a blob: url" );
+		});
+	});
 });


### PR DESCRIPTION
Opening an archived Epub in an ArrayBuffer without passing in options will
never resolve its `book.opened` Promise.

To see the problem run the test while removing the fix.