### PR TITLE
Fix left offset calculation of RTL prev navigation

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -517,9 +517,9 @@ class DefaultViewManager {
 			this.scrollLeft = this.container.scrollLeft;
 
 			if (this.settings.rtlScrollType === "default"){
-				left = this.container.scrollLeft + this.container.offsetWidth + this.layout.delta;
+				left = this.container.scrollLeft + this.container.offsetWidth;
 
-				if (left <= this.container.scrollWidth) {
+				if (left < this.container.scrollWidth) {
 					this.scrollBy(-this.layout.delta, 0, true);
 				} else {
 					prev = this.views.first().section.prev();


### PR DESCRIPTION
Fixed calculation issue when performing a prev navigation of RTL books.

The issue was skipping display of first page and jump into previous chapter

the scope of this issue/fix is within default manager