### PR TITLE
Run resizeCheck in requestAnimationFrame for ResizeObserver

### DIFF
--- a/src/contents.js
+++ b/src/contents.js
@@ -526,7 +526,7 @@ class Contents {
 	resizeObservers() {
 		// create an observer instance
 		this.observer = new ResizeObserver((e) => {
-			this.resizeCheck();
+			requestAnimationFrame(this.resizeCheck.bind(this));
 		});
 
 		// pass in the target node


### PR DESCRIPTION
Prevents `[Error] ResizeObserver loop completed with undelivered notifications.` errors in webkit.