### PR TITLE
Fix broken type that cause TypeScript compilation error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,8 @@ export { default as Book } from './book';
 export { default as EpubCFI } from './epubcfi';
 export { default as Rendition, Location } from './rendition';
 export { default as Contents } from './contents';
-export { default as Layout, NavItem } from './layout';
+export { default as Layout } from './layout';
+export { NavItem } from './navigation';
 
 declare namespace ePub {
 


### PR DESCRIPTION
They types are broken, causing TS compilation to fail with an error:

![image](https://user-images.githubusercontent.com/15803440/85926534-d07b9d00-b8a8-11ea-90a1-79d5898603c4.png)

This fixes issue #1078  