### PR TITLE
update layout before calculating location

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -712,6 +712,7 @@ class DefaultViewManager {
 	}
 
 	paginatedLocation(){
+		this.updateLayout();
 		let visible = this.visible();
 		let container = this.container.getBoundingClientRect();
 

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -634,6 +634,7 @@ class DefaultViewManager {
 	}
 
 	currentLocation(){
+		this.updateLayout();
 		if (this.isPaginated && this.settings.axis === "horizontal") {
 			this.location = this.paginatedLocation();
 		} else {
@@ -712,7 +713,6 @@ class DefaultViewManager {
 	}
 
 	paginatedLocation(){
-		this.updateLayout();
 		let visible = this.visible();
 		let container = this.container.getBoundingClientRect();
 


### PR DESCRIPTION
After spending several days to solve issues like #1103, found a solution/work-around for this issue. the original issue was that, when font-family or font size changes, the total page reported in `currentLocataion()` was wrong, as reported in #982. 

In this PR the `updateLayout()` will be called when `paginatedLocation()` is called.
hopefully closes #1103 and #982.