### PR TITLE
Return nested TOC with duplicate hrefs

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -149,17 +149,14 @@ class Navigation {
 	 */
 	parseNav(navHtml){
 		var navElement = querySelectorByType(navHtml, "nav", "toc");
-		var navItems = navElement ? qsa(navElement, "li") : [];
-		var length = navItems.length;
 		var list = [];
 
-		if(!navItems || length === 0) return list;
-
 		if (!navElement) return list;
-		if (!navElement.children) return list;
-		if (!navElement.children[0]) return list;
 
-		list = this.parseNavList(navElement.children[0]);
+		let navList = filterChildren(navElement, "ol", true);
+		if (!navList) return list;
+
+		list = this.parseNavList(navList);
 		return list;
 	}
 
@@ -176,7 +173,11 @@ class Navigation {
 		if (!navListHtml.children) return result;
 		
 		for (let i = 0; i < navListHtml.children.length; i++) {
-			result.push(this.navItem(navListHtml.children[i], parent));
+			const item = this.navItem(navListHtml.children[i], parent);
+
+			if (item) {
+				result.push(item);
+			}
 		}
 
 		return result;

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -151,27 +151,35 @@ class Navigation {
 		var navElement = querySelectorByType(navHtml, "nav", "toc");
 		var navItems = navElement ? qsa(navElement, "li") : [];
 		var length = navItems.length;
-		var i;
-		var toc = {};
 		var list = [];
-		var item, parent;
 
 		if(!navItems || length === 0) return list;
 
-		for (i = 0; i < length; ++i) {
-			item = this.navItem(navItems[i]);
-			if (item) {
-				toc[item.id] = item;
-				if(!item.parent) {
-					list.push(item);
-				} else {
-					parent = toc[item.parent];
-					parent.subitems.push(item);
-				}
-			}
+		if (!navElement) return list;
+		if (!navElement.children) return list;
+		if (!navElement.children[0]) return list;
+
+		list = this.parseNavList(navElement.children[0]);
+		return list;
+	}
+
+	/**
+	 * Parses lists in the toc
+	 * @param  {document} navListHtml
+	 * @param  {string} parent id
+	 * @return {array} navigation list
+	 */
+	parseNavList(navListHtml, parent) {
+		const result = [];
+
+		if (!navListHtml) return result;
+		if (!navListHtml.children) return result;
+		
+		for (let i = 0; i < navListHtml.children.length; i++) {
+			result.push(this.navItem(navListHtml.children[i], parent));
 		}
 
-		return list;
+		return result;
 	}
 
 	/**
@@ -180,7 +188,7 @@ class Navigation {
 	 * @param  {element} item
 	 * @return {object} navItem
 	 */
-	navItem(item){
+	navItem(item, parent) {
 		let id = item.getAttribute("id") || undefined;
 		let content = filterChildren(item, "a", true);
 
@@ -194,27 +202,11 @@ class Navigation {
 			id = src;
 		}
 		let text = content.textContent || "";
+
 		let subitems = [];
-		let parentItem = getParentByTagName(item, "li");
-		let parent;
-
-		if (parentItem) {
-			parent = parentItem.getAttribute("id");
-			if (!parent) {
-				const parentContent = filterChildren(parentItem, "a", true);
-				parent = parentContent && parentContent.getAttribute("href");
-      			}
-		}
-
-		while (!parent && parentItem) {
-			parentItem = getParentByTagName(parentItem, "li");
-			if (parentItem) {
-				parent = parentItem.getAttribute("id");
-				if (!parent) {
-					const parentContent = filterChildren(parentItem, "a", true);
-          				parent = parentContent && parentContent.getAttribute("href");
-        			}
-			}
+		let nested = filterChildren(item, "ol", true);
+		if (nested) {
+			subitems = 	this.parseNavList(nested, id);
 		}
 
 		return {


### PR DESCRIPTION
We ran into an issue where some books have a nav.xhtml in which subitems had the same href as the parent. 

In the current implementation of `navigation.js`, the navigation assumes that each navItem has a unique id. If the navItem's element doesn't have an id it will fallback to the href attribute. However, we found that a lot of books don't have unique hrefs(For example, Chapter 1 and Chapter 1.1 might have the same href even though they are 2 separate items in the TOC). This will result in all subitems of Chapter 1 being dropped.

This new approach will traverse the nav top-to-bottom.

**Potential Issues:**

- It will run into conflicts with `Navigation.unpack` because treats hrefs as unique.
- It will run into conflicts with `Navigation.get` because treats hrefs as unique.


