### PR TITLE
update Epub() type signature to reflect implementation

### DIFF
--- a/types/epub.d.ts
+++ b/types/epub.d.ts
@@ -2,5 +2,5 @@ import Book, { BookOptions } from "./book";
 
 export default Epub;
 
-declare function Epub(url: string, options?: BookOptions) : Book;
+declare function Epub(urlOrData: string | ArrayBuffer, options?: BookOptions) : Book;
 declare function Epub(options?: BookOptions) : Book;


### PR DESCRIPTION
`Epub()` function accepts an `ArrayBuffer` in addition to a `string`. This PR updates types to reflect that.