### PR TITLE
as it's not transpiled during build, provide mime.js as commonjs

### DIFF
--- a/libs/mime/mime.js
+++ b/libs/mime/mime.js
@@ -166,4 +166,4 @@ function lookup(filename) {
 	return filename && mimeTypes[filename.split(".").pop().toLowerCase()] || defaultValue;
 };
 
-export default { lookup };
+module.exports = { lookup };


### PR DESCRIPTION
`libs/mime.js` is in ES6 format, but it's not transpiled as part of `npm compile`, which only transpiles sources in `lib/` and `src/`; as a consequence, importing `epub.js` in a project that uses npm and webpack fails, since webpack normally expects `node_modules` to be already transpiled.

This PR is a minimal change to `libs/mime.js` to not need transpilation. An alternative might be to transpile `libs` along with `lib` and `src`.