### PR TITLE
* Fix moveTo for vertical writing mode.

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -343,6 +343,12 @@ class DefaultViewManager {
 			if (distX + this.layout.delta > this.container.scrollWidth) {
 				distX = this.container.scrollWidth - this.layout.delta;
 			}
+
+			distY = Math.floor(offset.top / this.layout.delta) * this.layout.delta;
+
+			if (distY + this.layout.delta > this.container.scrollHeight) {
+				distY = this.container.scrollHeight - this.layout.delta;
+			}
 		}
 		this.scrollTo(distX, distY, true);
 	}


### PR DESCRIPTION
This moveTo bug made rendition.display not working for vertical-lr or vertical-rl writing modes. After fixing this bug, rendition.display works with an ePub CFI bookmark or a percentage!