### PR TITLE
Update layout after crossing a section boundary

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -343,6 +343,12 @@ class DefaultViewManager {
 			if (distX + this.layout.delta > this.container.scrollWidth) {
 				distX = this.container.scrollWidth - this.layout.delta;
 			}
+
+			distY = Math.floor(offset.top / this.layout.delta) * this.layout.delta;
+
+			if (distY + this.layout.delta > this.container.scrollHeight) {
+				distY = this.container.scrollHeight - this.layout.delta;
+			}
 		}
 		this.scrollTo(distX, distY, true);
 	}

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -492,6 +492,8 @@ class DefaultViewManager {
 
 		if(next) {
 			this.clear();
+			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && next.properties.includes("page-spread-right")) {
@@ -583,6 +585,8 @@ class DefaultViewManager {
 
 		if(prev) {
 			this.clear();
+			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && typeof prev.prev() !== "object") {


### PR DESCRIPTION
An ePub file might contain various writing-mode XHTML files. For example, a cover page uses horizontal-tb but a section uses vertical-rl. Without updating layout after crossing a section boundary, epubjs may use an incorrect layout.delta to calculate a scroll position for prev() or next().