### PR TITLE
Fix navigation with proper fraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.90",
+  "version": "0.3.92",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "epubjs",
-  "version": "0.3.88",
+  "name": "epubjs-myh",
+  "version": "0.3.89",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",
@@ -24,7 +24,7 @@
     "watch": "babel --watch -d lib/ src/",
     "prepare": "npm run compile && npm run build && npm run minify && npm run legacy && npm run productionLegacy"
   },
-  "author": "fchasen@gmail.com",
+  "author": "myh@live.com",
   "license": "BSD-2-Clause",
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.92",
+  "version": "0.3.93",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.89",
+  "version": "0.3.90",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",
@@ -16,10 +16,10 @@
     "docs:md": "documentation build src/epub.js -f md -o documentation/md/API.md",
     "lint": "eslint -c .eslintrc.js src; exit 0",
     "start": "webpack-dev-server --inline --d",
-    "build": "NODE_ENV=production webpack --progress",
-    "minify": "NODE_ENV=production MINIMIZE=true webpack --progress",
-    "legacy": "NODE_ENV=production LEGACY=true webpack --progress",
-    "productionLegacy": "NODE_ENV=production MINIMIZE=true LEGACY=true webpack --progress",
+    "build": "set NODE_ENV=production && webpack --progress",
+    "minify": "set NODE_ENV=production && set MINIMIZE=true && webpack --progress",
+    "legacy": "set NODE_ENV=production && set LEGACY=true && webpack --progress",
+    "productionLegacy": "set NODE_ENV=production && set MINIMIZE=true && set LEGACY=true && webpack --progress",
     "compile": "babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "prepare": "npm run compile && npm run build && npm run minify && npm run legacy && npm run productionLegacy"

--- a/src/layout.js
+++ b/src/layout.js
@@ -100,7 +100,7 @@ class Layout {
 	 * @param  {number} _height height of the rendering
 	 * @param  {number} _gap    width of the gap between columns
 	 */
-	calculate(_width, _height, _gap){
+	calculate(_width, _height, _gap, axis){
 
 		var divisor = 1;
 		var gap = _gap || 0;
@@ -110,7 +110,7 @@ class Layout {
 		var width = _width;
 		var height = _height;
 
-		var section = Math.floor(width / 12);
+		var section = Math.floor((axis === 'vertical' ? height : width) / 12);
 
 		var columnWidth;
 		var spreadWidth;

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -343,6 +343,12 @@ class DefaultViewManager {
 			if (distX + this.layout.delta > this.container.scrollWidth) {
 				distX = this.container.scrollWidth - this.layout.delta;
 			}
+
+			distY = Math.floor(offset.top / this.layout.delta) * this.layout.delta;
+
+			if (distY + this.layout.delta > this.container.scrollHeight) {
+				distY = this.container.scrollHeight - this.layout.delta;
+			}
 		}
 		this.scrollTo(distX, distY, true);
 	}

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -457,6 +457,8 @@ class DefaultViewManager {
 			this.scrollLeft = this.container.scrollLeft;
 
 			if (this.settings.rtlScrollType === "default"){
+				this.scrollLeft = Math.floor(this.container.scrollLeft);
+				// this.container.scrollLeft could has fractional part.
 				left = Math.floor(this.container.scrollLeft);
 
 				if (left > 0) {
@@ -492,6 +494,7 @@ class DefaultViewManager {
 
 		if(next) {
 			this.clear();
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && next.properties.includes("page-spread-right")) {
@@ -565,9 +568,10 @@ class DefaultViewManager {
 
 		} else if (this.isPaginated && this.settings.axis === "vertical") {
 
-			this.scrollTop = this.container.scrollTop;
+			this.scrollTop = Math.floor(this.container.scrollTop);
 
-			let top = this.container.scrollTop;
+			// this.container.scrollTop could has fractional part.
+			let top = Math.floor(this.container.scrollTop);
 
 			if(top > 0) {
 				this.scrollBy(0, -(this.layout.height), true);
@@ -583,6 +587,7 @@ class DefaultViewManager {
 
 		if(prev) {
 			this.clear();
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && typeof prev.prev() !== "object") {
@@ -994,7 +999,6 @@ class DefaultViewManager {
 				this.layout.spread(this.layout.settings.spread);
 			}
 		}
-		this.updateLayout();
 	}
 
 	updateFlow(flow, defaultScrolledOverflow="auto"){

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -457,7 +457,7 @@ class DefaultViewManager {
 			this.scrollLeft = this.container.scrollLeft;
 
 			if (this.settings.rtlScrollType === "default"){
-				left = this.container.scrollLeft;
+				left = Math.floor(this.container.scrollLeft);
 
 				if (left > 0) {
 					this.scrollBy(this.layout.delta, 0, true);
@@ -492,8 +492,6 @@ class DefaultViewManager {
 
 		if(next) {
 			this.clear();
-			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
-			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && next.properties.includes("page-spread-right")) {
@@ -585,8 +583,6 @@ class DefaultViewManager {
 
 		if(prev) {
 			this.clear();
-			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
-			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && typeof prev.prev() !== "object") {
@@ -998,6 +994,7 @@ class DefaultViewManager {
 				this.layout.spread(this.layout.settings.spread);
 			}
 		}
+		this.updateLayout();
 	}
 
 	updateFlow(flow, defaultScrolledOverflow="auto"){

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -930,12 +930,13 @@ class DefaultViewManager {
 		this._stageSize = this.stage.size();
 
 		if(!this.isPaginated) {
-			this.layout.calculate(this._stageSize.width, this._stageSize.height);
+			this.layout.calculate(this._stageSize.width, this._stageSize.height, undefined, this.settings.axis);
 		} else {
 			this.layout.calculate(
 				this._stageSize.width,
 				this._stageSize.height,
-				this.settings.gap
+				this.settings.gap,
+				this.settings.axis
 			);
 
 			// Set the look ahead offset for what is visible


### PR DESCRIPTION
These two lines could have numbers between 0 and 1 (proper fractions) during navigations:
https://github.com/futurepress/epub.js/blob/a1e77b745ba3d0ba122d70d276a08afe44270d17/src/managers/default/index.js#L451
https://github.com/futurepress/epub.js/blob/a1e77b745ba3d0ba122d70d276a08afe44270d17/src/managers/default/index.js#L562

Even if an ePub section (e.g. a cover page or a table of content page) has only one page, a proper fraction causes prev() or next() can't correct go to the previous or next section, because these condition tests are true:
https://github.com/futurepress/epub.js/blob/a1e77b745ba3d0ba122d70d276a08afe44270d17/src/managers/default/index.js#L451
https://github.com/futurepress/epub.js/blob/a1e77b745ba3d0ba122d70d276a08afe44270d17/src/managers/default/index.js#L562
A browser inspector confirms the problem (this.container.scrollLeft has a value 0.8000...):
<img src="https://user-images.githubusercontent.com/49478723/93551962-d5308880-f9a1-11ea-9593-5108956f5860.png" width="100%" height="100%" />
In user perspective, user has to execute prev() or next() twice to correctly go to the previous or next section!

This pull request fixes only two navigation cases (depending on section layouts), not all navigation cases, because my tested ePub files can only triggers these two cases.
