### PR TITLE
Fix locationOf with empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.90",
+  "version": "0.3.92",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.93",
+  "version": "0.3.97",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "epubjs",
-  "version": "0.3.88",
+  "name": "epubjs-myh",
+  "version": "0.3.89",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",
@@ -24,7 +24,7 @@
     "watch": "babel --watch -d lib/ src/",
     "prepare": "npm run compile && npm run build && npm run minify && npm run legacy && npm run productionLegacy"
   },
-  "author": "fchasen@gmail.com",
+  "author": "myh@live.com",
   "license": "BSD-2-Clause",
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.92",
+  "version": "0.3.93",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.97",
+  "version": "0.3.98",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.89",
+  "version": "0.3.90",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",
@@ -16,10 +16,10 @@
     "docs:md": "documentation build src/epub.js -f md -o documentation/md/API.md",
     "lint": "eslint -c .eslintrc.js src; exit 0",
     "start": "webpack-dev-server --inline --d",
-    "build": "NODE_ENV=production webpack --progress",
-    "minify": "NODE_ENV=production MINIMIZE=true webpack --progress",
-    "legacy": "NODE_ENV=production LEGACY=true webpack --progress",
-    "productionLegacy": "NODE_ENV=production MINIMIZE=true LEGACY=true webpack --progress",
+    "build": "set NODE_ENV=production && webpack --progress",
+    "minify": "set NODE_ENV=production && set MINIMIZE=true && webpack --progress",
+    "legacy": "set NODE_ENV=production && set LEGACY=true && webpack --progress",
+    "productionLegacy": "set NODE_ENV=production && set MINIMIZE=true && set LEGACY=true && webpack --progress",
     "compile": "babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "prepare": "npm run compile && npm run build && npm run minify && npm run legacy && npm run productionLegacy"

--- a/src/contents.js
+++ b/src/contents.js
@@ -655,7 +655,9 @@ class Contents {
 							console.error(e, e.stack);
 						}
 					} else {
-						position = range.getBoundingClientRect();
+						// range.toString() might be an empty string and range.getBoundingClientRect() returns a all-zeros position.
+						// Thus, we use the parent element containing the range to get a valid bounding rect.
+						position = range.startContainer.parentElement.getBoundingClientRect();
 					}
 				}
 			}

--- a/src/layout.js
+++ b/src/layout.js
@@ -100,7 +100,7 @@ class Layout {
 	 * @param  {number} _height height of the rendering
 	 * @param  {number} _gap    width of the gap between columns
 	 */
-	calculate(_width, _height, _gap){
+	calculate(_width, _height, _gap, axis){
 
 		var divisor = 1;
 		var gap = _gap || 0;
@@ -110,7 +110,7 @@ class Layout {
 		var width = _width;
 		var height = _height;
 
-		var section = Math.floor(width / 12);
+		var section = Math.floor((axis === 'vertical' ? height : width) / 12);
 
 		var columnWidth;
 		var spreadWidth;

--- a/src/layout.js
+++ b/src/layout.js
@@ -100,17 +100,17 @@ class Layout {
 	 * @param  {number} _height height of the rendering
 	 * @param  {number} _gap    width of the gap between columns
 	 */
-	calculate(_width, _height, _gap, axis){
+	calculate(_width, _height, _gap){
 
 		var divisor = 1;
-		var gap = _gap || 0;
+		var gap = _gap || 20;
 
 		//-- Check the width and create even width columns
 		// var fullWidth = Math.floor(_width);
 		var width = _width;
 		var height = _height;
 
-		var section = Math.floor((axis === 'vertical' ? height : width) / 12);
+		//var section = Math.floor(width / 12);
 
 		var columnWidth;
 		var spreadWidth;
@@ -123,9 +123,11 @@ class Layout {
 			divisor = 1;
 		}
 
+		/*
 		if (this.name === "reflowable" && this._flow === "paginated" && !(_gap >= 0)) {
 			gap = ((section % 2 === 0) ? section : section - 1);
 		}
+		*/
 
 		if (this.name === "pre-paginated" ) {
 			gap = 0;

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -343,6 +343,12 @@ class DefaultViewManager {
 			if (distX + this.layout.delta > this.container.scrollWidth) {
 				distX = this.container.scrollWidth - this.layout.delta;
 			}
+
+			distY = Math.floor(offset.top / this.layout.delta) * this.layout.delta;
+
+			if (distY + this.layout.delta > this.container.scrollHeight) {
+				distY = this.container.scrollHeight - this.layout.delta;
+			}
 		}
 		this.scrollTo(distX, distY, true);
 	}

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -457,6 +457,8 @@ class DefaultViewManager {
 			this.scrollLeft = this.container.scrollLeft;
 
 			if (this.settings.rtlScrollType === "default"){
+				this.scrollLeft = Math.floor(this.container.scrollLeft);
+				// this.container.scrollLeft could has fractional part.
 				left = Math.floor(this.container.scrollLeft);
 
 				if (left > 0) {
@@ -492,6 +494,7 @@ class DefaultViewManager {
 
 		if(next) {
 			this.clear();
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && next.properties.includes("page-spread-right")) {
@@ -565,9 +568,10 @@ class DefaultViewManager {
 
 		} else if (this.isPaginated && this.settings.axis === "vertical") {
 
-			this.scrollTop = this.container.scrollTop;
+			this.scrollTop = Math.floor(this.container.scrollTop);
 
-			let top = this.container.scrollTop;
+			// this.container.scrollTop could has fractional part.
+			let top = Math.floor(this.container.scrollTop);
 
 			if(top > 0) {
 				this.scrollBy(0, -(this.layout.height), true);
@@ -583,6 +587,7 @@ class DefaultViewManager {
 
 		if(prev) {
 			this.clear();
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && typeof prev.prev() !== "object") {
@@ -994,7 +999,6 @@ class DefaultViewManager {
 				this.layout.spread(this.layout.settings.spread);
 			}
 		}
-		this.updateLayout();
 	}
 
 	updateFlow(flow, defaultScrolledOverflow="auto"){

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -457,7 +457,7 @@ class DefaultViewManager {
 			this.scrollLeft = this.container.scrollLeft;
 
 			if (this.settings.rtlScrollType === "default"){
-				left = this.container.scrollLeft;
+				left = Math.floor(this.container.scrollLeft);
 
 				if (left > 0) {
 					this.scrollBy(this.layout.delta, 0, true);
@@ -492,8 +492,6 @@ class DefaultViewManager {
 
 		if(next) {
 			this.clear();
-			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
-			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && next.properties.includes("page-spread-right")) {
@@ -585,8 +583,6 @@ class DefaultViewManager {
 
 		if(prev) {
 			this.clear();
-			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
-			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && typeof prev.prev() !== "object") {
@@ -998,6 +994,7 @@ class DefaultViewManager {
 				this.layout.spread(this.layout.settings.spread);
 			}
 		}
+		this.updateLayout();
 	}
 
 	updateFlow(flow, defaultScrolledOverflow="auto"){

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -930,12 +930,13 @@ class DefaultViewManager {
 		this._stageSize = this.stage.size();
 
 		if(!this.isPaginated) {
-			this.layout.calculate(this._stageSize.width, this._stageSize.height);
+			this.layout.calculate(this._stageSize.width, this._stageSize.height, undefined, this.settings.axis);
 		} else {
 			this.layout.calculate(
 				this._stageSize.width,
 				this._stageSize.height,
-				this.settings.gap
+				this.settings.gap,
+				this.settings.axis
 			);
 
 			// Set the look ahead offset for what is visible


### PR DESCRIPTION
When using `book.locations.generate` and `rendition.display` with a proper fraction (between 0 and 1) value, it has a possibility that the ePub CFI range contains only an empty string. It causes this line returns a all-zeros position:
https://github.com/futurepress/epub.js/blob/a1e77b745ba3d0ba122d70d276a08afe44270d17/src/contents.js#L658
This browser inspector screenshot shows the problem:
<img src="https://user-images.githubusercontent.com/49478723/93561377-a2dd5600-f9b6-11ea-9a47-9b1cd14f9672.png" width="100%" />

To fix this problem, we can use the parent element containing the range to get a valid bounding rect.
`position = range.startContainer.parentElement.getBoundingClientRect();`