### PR TITLE
Add scrollbar support for scroll flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.98",
+  "version": "0.3.99",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.90",
+  "version": "0.3.92",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.99",
+  "version": "0.3.100",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.93",
+  "version": "0.3.97",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "epubjs",
-  "version": "0.3.88",
+  "name": "epubjs-myh",
+  "version": "0.3.89",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",
@@ -24,7 +24,7 @@
     "watch": "babel --watch -d lib/ src/",
     "prepare": "npm run compile && npm run build && npm run minify && npm run legacy && npm run productionLegacy"
   },
-  "author": "fchasen@gmail.com",
+  "author": "myh@live.com",
   "license": "BSD-2-Clause",
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.92",
+  "version": "0.3.93",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.97",
+  "version": "0.3.98",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-myh",
-  "version": "0.3.89",
+  "version": "0.3.90",
   "description": "Parse and Render Epubs",
   "main": "lib/index.js",
   "module": "src/index.js",
@@ -16,10 +16,10 @@
     "docs:md": "documentation build src/epub.js -f md -o documentation/md/API.md",
     "lint": "eslint -c .eslintrc.js src; exit 0",
     "start": "webpack-dev-server --inline --d",
-    "build": "NODE_ENV=production webpack --progress",
-    "minify": "NODE_ENV=production MINIMIZE=true webpack --progress",
-    "legacy": "NODE_ENV=production LEGACY=true webpack --progress",
-    "productionLegacy": "NODE_ENV=production MINIMIZE=true LEGACY=true webpack --progress",
+    "build": "set NODE_ENV=production && webpack --progress",
+    "minify": "set NODE_ENV=production && set MINIMIZE=true && webpack --progress",
+    "legacy": "set NODE_ENV=production && set LEGACY=true && webpack --progress",
+    "productionLegacy": "set NODE_ENV=production && set MINIMIZE=true && set LEGACY=true && webpack --progress",
     "compile": "babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "prepare": "npm run compile && npm run build && npm run minify && npm run legacy && npm run productionLegacy"

--- a/src/contents.js
+++ b/src/contents.js
@@ -655,7 +655,9 @@ class Contents {
 							console.error(e, e.stack);
 						}
 					} else {
-						position = range.getBoundingClientRect();
+						// range.toString() might be an empty string and range.getBoundingClientRect() returns a all-zeros position.
+						// Thus, we use the parent element containing the range to get a valid bounding rect.
+						position = range.startContainer.parentElement.getBoundingClientRect();
 					}
 				}
 			}

--- a/src/layout.js
+++ b/src/layout.js
@@ -100,7 +100,7 @@ class Layout {
 	 * @param  {number} _height height of the rendering
 	 * @param  {number} _gap    width of the gap between columns
 	 */
-	calculate(_width, _height, _gap){
+	calculate(_width, _height, _gap, axis){
 
 		var divisor = 1;
 		var gap = _gap || 0;
@@ -110,7 +110,7 @@ class Layout {
 		var width = _width;
 		var height = _height;
 
-		var section = Math.floor(width / 12);
+		var section = Math.floor((axis === 'vertical' ? height : width) / 12);
 
 		var columnWidth;
 		var spreadWidth;

--- a/src/layout.js
+++ b/src/layout.js
@@ -100,17 +100,17 @@ class Layout {
 	 * @param  {number} _height height of the rendering
 	 * @param  {number} _gap    width of the gap between columns
 	 */
-	calculate(_width, _height, _gap, axis){
+	calculate(_width, _height, _gap){
 
 		var divisor = 1;
-		var gap = _gap || 0;
+		var gap = _gap || 20;
 
 		//-- Check the width and create even width columns
 		// var fullWidth = Math.floor(_width);
 		var width = _width;
 		var height = _height;
 
-		var section = Math.floor((axis === 'vertical' ? height : width) / 12);
+		//var section = Math.floor(width / 12);
 
 		var columnWidth;
 		var spreadWidth;
@@ -123,9 +123,11 @@ class Layout {
 			divisor = 1;
 		}
 
+		/*
 		if (this.name === "reflowable" && this._flow === "paginated" && !(_gap >= 0)) {
 			gap = ((section % 2 === 0) ? section : section - 1);
 		}
+		*/
 
 		if (this.name === "pre-paginated" ) {
 			gap = 0;

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -343,6 +343,12 @@ class DefaultViewManager {
 			if (distX + this.layout.delta > this.container.scrollWidth) {
 				distX = this.container.scrollWidth - this.layout.delta;
 			}
+
+			distY = Math.floor(offset.top / this.layout.delta) * this.layout.delta;
+
+			if (distY + this.layout.delta > this.container.scrollHeight) {
+				distY = this.container.scrollHeight - this.layout.delta;
+			}
 		}
 		this.scrollTo(distX, distY, true);
 	}

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -457,6 +457,8 @@ class DefaultViewManager {
 			this.scrollLeft = this.container.scrollLeft;
 
 			if (this.settings.rtlScrollType === "default"){
+				this.scrollLeft = Math.floor(this.container.scrollLeft);
+				// this.container.scrollLeft could has fractional part.
 				left = Math.floor(this.container.scrollLeft);
 
 				if (left > 0) {
@@ -492,6 +494,7 @@ class DefaultViewManager {
 
 		if(next) {
 			this.clear();
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && next.properties.includes("page-spread-right")) {
@@ -565,9 +568,10 @@ class DefaultViewManager {
 
 		} else if (this.isPaginated && this.settings.axis === "vertical") {
 
-			this.scrollTop = this.container.scrollTop;
+			this.scrollTop = Math.floor(this.container.scrollTop);
 
-			let top = this.container.scrollTop;
+			// this.container.scrollTop could has fractional part.
+			let top = Math.floor(this.container.scrollTop);
 
 			if(top > 0) {
 				this.scrollBy(0, -(this.layout.height), true);
@@ -583,6 +587,7 @@ class DefaultViewManager {
 
 		if(prev) {
 			this.clear();
+			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && typeof prev.prev() !== "object") {
@@ -994,7 +999,6 @@ class DefaultViewManager {
 				this.layout.spread(this.layout.settings.spread);
 			}
 		}
-		this.updateLayout();
 	}
 
 	updateFlow(flow, defaultScrolledOverflow="auto"){

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -87,9 +87,9 @@ class DefaultViewManager {
 		this._bounds = this.bounds();
 		this._stageSize = this.stage.size();
 
+
 		// Set the dimensions for views
-		this.viewSettings.width = this._stageSize.width;
-		this.viewSettings.height = this._stageSize.height;
+		this.updateSize(this._stageSize.width, this._stageSize.height);
 
 		// Function to handle a resize event.
 		// Will only attach if width and height are both fixed.
@@ -220,9 +220,11 @@ class DefaultViewManager {
 		// Clear current views
 		this.clear();
 
+		/* Redundant codes? this.updateLayout() will update them!?
 		// Update for new views
 		this.viewSettings.width = this._stageSize.width;
 		this.viewSettings.height = this._stageSize.height;
+		*/
 
 		this.updateLayout();
 
@@ -948,10 +950,24 @@ class DefaultViewManager {
 		}
 
 		// Set the dimensions for views
-		this.viewSettings.width = this.layout.width;
-		this.viewSettings.height = this.layout.height;
+		this.updateSize(this.layout.width, this.layout.height);
 
 		this.setLayout(this.layout);
+	}
+
+	updateSize(width, height) {
+		if (this.layout._flow === "scrolled") {
+			if (this.settings.axis === "vertical") {
+				this.viewSettings.width = width - this.settings.scrollbarWidth;
+				this.viewSettings.height = height;
+			} else {
+				this.viewSettings.width = width;
+				this.viewSettings.height = height - this.settings.scrollbarWidth;
+			}
+		} else {
+			this.viewSettings.width = width;
+			this.viewSettings.height = height;
+		}
 	}
 
 	setLayout(layout){

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -457,7 +457,7 @@ class DefaultViewManager {
 			this.scrollLeft = this.container.scrollLeft;
 
 			if (this.settings.rtlScrollType === "default"){
-				left = this.container.scrollLeft;
+				left = Math.floor(this.container.scrollLeft);
 
 				if (left > 0) {
 					this.scrollBy(this.layout.delta, 0, true);
@@ -492,8 +492,6 @@ class DefaultViewManager {
 
 		if(next) {
 			this.clear();
-			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
-			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && next.properties.includes("page-spread-right")) {
@@ -585,8 +583,6 @@ class DefaultViewManager {
 
 		if(prev) {
 			this.clear();
-			// The new section may have a different writing-mode from the old section. Thus, we need to update layout.
-			this.updateLayout();
 
 			let forceRight = false;
 			if (this.layout.name === "pre-paginated" && this.layout.divisor === 2 && typeof prev.prev() !== "object") {
@@ -998,6 +994,7 @@ class DefaultViewManager {
 				this.layout.spread(this.layout.settings.spread);
 			}
 		}
+		this.updateLayout();
 	}
 
 	updateFlow(flow, defaultScrolledOverflow="auto"){

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -930,12 +930,13 @@ class DefaultViewManager {
 		this._stageSize = this.stage.size();
 
 		if(!this.isPaginated) {
-			this.layout.calculate(this._stageSize.width, this._stageSize.height);
+			this.layout.calculate(this._stageSize.width, this._stageSize.height, undefined, this.settings.axis);
 		} else {
 			this.layout.calculate(
 				this._stageSize.width,
 				this._stageSize.height,
-				this.settings.gap
+				this.settings.gap,
+				this.settings.axis
 			);
 
 			// Set the look ahead offset for what is visible

--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -610,7 +610,15 @@ class IframeView {
 		}
 
 		let m = new Highlight(range, className, data, attributes);
-		let h = this.pane.addMark(m);
+		let h;
+		try {
+			h = this.pane.addMark(m);
+		} catch (err) {
+			// Print error only for invalid highlights.
+			// Throwing an error here will cause ePub display stops after navigate out and then in a section with an invalid highlight.
+			console.error(err);
+			return;
+		}
 
 		this.highlights[cfiRange] = { "mark": h, "element": h.element, "listeners": [emitter, cb] };
 

--- a/types/rendition.d.ts
+++ b/types/rendition.d.ts
@@ -15,6 +15,7 @@ export interface RenditionOptions {
   manager?: string | Function | object,
   view?: string | Function | object,
   flow?: string,
+  scrollbarWidth?: number,
   layout?: string,
   spread?: string,
   minSpreadWidth?: number,


### PR DESCRIPTION
Add an option scrollbarWidth to control reserved space between epub-container and iframe for scrollbar for scroll flow. Then, we can use these CSS codes to enable horizontal or vertical scrollbar:
https://github.com/MrMYHuang/cbetar2/blob/master/src/pages/EPubViewPage.css

Without the reserved space, epub-container's scrollbar overlaps with iframe content ☹ The screenshot shows the problem that the blue horizontal scrollbar overlaps the texts:
<img src="https://user-images.githubusercontent.com/12458706/93724343-c7b11380-fbd8-11ea-9062-c6c466b4203d.png" width="100%" />

With a reserved space, the overlap problem is fixed:
<img src="https://user-images.githubusercontent.com/12458706/93724393-29717d80-fbd9-11ea-8d93-f483d70f7d00.png" width="100%" />

