### PR TITLE
fix the getRange in Book return type to Promise

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -696,7 +696,7 @@ class Book {
 	/**
 	 * Find a DOM Range for a given CFI Range
 	 * @param  {EpubCFI} cfiRange a epub cfi range
-	 * @return {Range}
+	 * @return {Promise}
 	 */
 	getRange(cfiRange) {
 		var cfi = new EpubCFI(cfiRange);

--- a/types/book.d.ts
+++ b/types/book.d.ts
@@ -71,7 +71,7 @@ export default class Book {
 
     determineType(input: string): string;
 
-    getRange(cfiRange: string): Range;
+    getRange(cfiRange: string): Promise<Range>;
 
     key(identifier?: string): string;
 


### PR DESCRIPTION
To make sense with the **highlights** example (and in my TypeScript uses), the return type of `getRange` method in the `Book` class must be Promise and not Range:

```js
book.getRange(cfiRange).then(function (range) {
        var text;
...
```

This pull request fix this.