### PR TITLE
remove pane to force redraw on render

### DIFF
--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -816,6 +816,11 @@ class IframeView {
 			this.stopExpanding = true;
 			this.element.removeChild(this.iframe);
 
+			if (this.pane) {
+				this.pane.element.remove();
+				this.pane = undefined;
+			}
+
 			this.iframe = undefined;
 			this.contents = undefined;
 


### PR DESCRIPTION
## What's in this PR?

Currently, when you have annotations in a section, then move 2 or more sections away, they become unclickable.  This happens because the `iframe` gets removed from the view but the `svg` (added through the `pane`) doesn't.  So, when the `iframe` is added back after navigating, the `svg` element comes _before_ the `iframe` and is hidden behind it.

Removing the `pane` forces the `underline | highlight |  mark` functions to recreate the pane.

## How to test this

On `master`, go to the "highlights" example page via http://localhost:8080/examples/highlights.html
Make a highlight on the first page.
If you click your highlight, you should see something logged in your console via https://github.com/futurepress/epub.js/blob/master/examples/highlights.html#L119

Now, navigate all the way back to the beginning of the book (which is two sections prior).
Then, navigate forward again.
Your annotations are still there, but clicking them does nothing (no console log).

Checkout this branch and you should see it resolves the issues.  Your annotations are still there and are clickable.