### PR TITLE
fix marks example

### DIFF
--- a/examples/marks.html
+++ b/examples/marks.html
@@ -69,7 +69,7 @@
     // Apply a class to selected text
     rendition.on("selected", function(cfiRange, contents) {
 
-      var m = contents.mark(cfiRange, {'something' : true}, (e) => {
+      rendition.annotations.mark(cfiRange, {'something' : true}, (e) => {
         var bounds = e.target.getBoundingClientRect();
         var clientX = e.clientX;
 


### PR DESCRIPTION
## What's in this PR?

Was searching a separate issue when I came across this [StackOverflow post](https://stackoverflow.com/questions/65951070/how-to-implement-text-highlighting-in-epub-react-reader/66806975#66806975).  When I looked into it, I saw that the example was not correct (at least not with the current API).  The example calls `content.mark` however, the `mark` method lives on `annotations`.

This PR simply updates it.

## How to test

Run the app.
Go to `/examples/marks.html`
Highlight some text.
You should see a new `<a>` tag appended to the `.epub-view` div with the cfiRange specified by your highlight