### PR TITLE
Fix xmldom DOMParser import

### DIFF
--- a/src/section.js
+++ b/src/section.js
@@ -4,7 +4,7 @@ import Hook from "./utils/hook";
 import { sprint } from "./utils/core";
 import { replaceBase } from "./utils/replacements";
 import Request from "./utils/request";
-import { XMLDOMParser as XMLDOMSerializer } from "xmldom";
+import { DOMParser as XMLDOMSerializer } from "xmldom";
 
 /**
  * Represents a Section of the Book


### PR DESCRIPTION
`xmldom` does not export ~`XMLDOMParser`~, it exports `DOMParser` instead (https://www.npmjs.com/package/xmldom).

When building an app based on this version, the following error occurs, which **breaks the build**:

```
./node_modules/epubjs/src/section.js:100:18-34 - Error: export 'XMLDOMParser' (imported as 'XMLDOMSerializer') was not found in 'xmldom' (possible exports: DOMImplementation, DOMParser, XMLSerializer)
```

It seems to be a simple misunderstanding/misspelling.

Making this small correction manually in the local node_modules fixes this, but it's obviously not a proper long-term solution.

This was [mentioned](https://github.com/futurepress/epub.js/issues/1196#issue-907154930) [before](https://github.com/futurepress/epub.js/issues/1157#issue-757703370).

[This is where](https://github.com/futurepress/epub.js/commit/cb4facb6c2cd3309fcb1ebfb40493b5c9add8695#diff-593c984a985d5132f770106a01102ecff78b6f6324f62e87ff37a91c6af7ce2eR7) this bug was introduced,

PS: thanks for developing this great package! 👍 