### PR TITLE
pass base64 flag in coverUrl | Book.coverUrl() hardcoded with blob ? No Base 64 

### DIFF
--- a/src/book.js
+++ b/src/book.js
@@ -1,5 +1,5 @@
 import EventEmitter from "event-emitter";
-import {extend, defer} from "./utils/core";
+import { extend, defer } from "./utils/core";
 import Url from "./utils/url";
 import Path from "./utils/path";
 import Spine from "./spine";
@@ -50,10 +50,10 @@ const INPUT_TYPE = {
 class Book {
 	constructor(url, options) {
 		// Allow passing just options to the Book
-		if (typeof(options) === "undefined" &&
-			  typeof(url) !== "string" &&
-		    url instanceof Blob === false &&
-		    url instanceof ArrayBuffer === false) {
+		if (typeof (options) === "undefined" &&
+			typeof (url) !== "string" &&
+			url instanceof Blob === false &&
+			url instanceof ArrayBuffer === false) {
 			options = url;
 			url = undefined;
 		}
@@ -229,9 +229,9 @@ class Book {
 			this.store(this.settings.store);
 		}
 
-		if(url) {
+		if (url) {
 			this.open(url, this.settings.openAs).catch((error) => {
-				var err = new Error("Cannot load book at "+ url );
+				var err = new Error("Cannot load book at " + url);
 				this.emit(EVENTS.BOOK.OPEN_FAILED, err);
 			});
 		}
@@ -261,10 +261,10 @@ class Book {
 			this.url = new Url("/", "");
 			opening = this.request(input, "binary", this.settings.requestCredentials, this.settings.requestHeaders)
 				.then(this.openEpub.bind(this));
-		} else if(type == INPUT_TYPE.OPF) {
+		} else if (type == INPUT_TYPE.OPF) {
 			this.url = new Url(input);
 			opening = this.openPackaging(this.url.Path.toString());
-		} else if(type == INPUT_TYPE.MANIFEST) {
+		} else if (type == INPUT_TYPE.MANIFEST) {
 			this.url = new Url(input);
 			opening = this.openManifest(this.url.Path.toString());
 		} else {
@@ -345,7 +345,7 @@ class Book {
 	 */
 	load(path) {
 		var resolved = this.resolve(path);
-		if(this.archived) {
+		if (this.archived) {
 			return this.archive.request(resolved);
 		} else {
 			return this.request(resolved, null, this.settings.requestCredentials, this.settings.requestHeaders);
@@ -373,7 +373,7 @@ class Book {
 			resolved = this.path.resolve(path);
 		}
 
-		if(absolute != false && this.url) {
+		if (absolute != false && this.url) {
 			resolved = this.url.resolve(resolved);
 		}
 
@@ -416,7 +416,7 @@ class Book {
 			return INPUT_TYPE.BASE64;
 		}
 
-		if(typeof(input) != "string") {
+		if (typeof (input) != "string") {
 			return INPUT_TYPE.BINARY;
 		}
 
@@ -433,15 +433,15 @@ class Book {
 			return INPUT_TYPE.DIRECTORY;
 		}
 
-		if(extension === "epub"){
+		if (extension === "epub") {
 			return INPUT_TYPE.EPUB;
 		}
 
-		if(extension === "opf"){
+		if (extension === "opf") {
 			return INPUT_TYPE.OPF;
 		}
 
-		if(extension === "json"){
+		if (extension === "json") {
 			return INPUT_TYPE.MANIFEST;
 		}
 	}
@@ -496,15 +496,15 @@ class Book {
 
 		this.isOpen = true;
 
-		if(this.archived || this.settings.replacements && this.settings.replacements != "none") {
+		if (this.archived || this.settings.replacements && this.settings.replacements != "none") {
 			this.replacements().then(() => {
 				this.loaded.displayOptions.then(() => {
 					this.opening.resolve(this);
 				});
 			})
-			.catch((err) => {
-				console.error(err);
-			});
+				.catch((err) => {
+					console.error(err);
+				});
 		} else {
 			// Resolve book opened promise
 			this.loaded.displayOptions.then(() => {
@@ -670,7 +670,7 @@ class Book {
 			}
 
 			if (this.archived) {
-				return this.archive.createUrl(this.cover);
+				return this.archive.createUrl(this.cover, { "base64": (this.settings.replacements === "base64") });
 			} else {
 				return this.cover;
 			}


### PR DESCRIPTION
## Background
I am working on electron based application (an embedded express server in electron wrapper) and I am getting the blob url something like blob:localhost:3000/<random-id> ...

I just saw the code and looks like the createUrl method inside the coverUrl does not have second parameter and it defaults to blob always but I need base64 so I passed `{ replacements: "base64" }` and a little change to recipe got it working ...

## Problem
```javascript
coverUrl() {
   return this.loaded.cover.then(() => {
    if (!this.cover) {
      return null;
    }
    if (this.archived) {
      return this.archive.createUrl(this.cover);
    } else {
      return this.cover;
    }
  });
}
```

## Solution
Is there any issue passing the 2nd argument containing base64 flag ? like in the other versions ?
something like : 
```javascript
coverUrl() {
   return this.loaded.cover.then(() => {
    if (!this.cover) {
      return null;
    }
    if (this.archived) {
      return this.archive.createUrl(this.cover, {"base64": this.settings.replacements === "base64"});
    } else {
      return this.cover;
    }
  });
}
```

Note: There are some indentation changes showing up and I think Test cases might also have to be updated but I didn't ...
And I don't have any experience of contributing so if it fits in then good .. if not then Excuse me .. :)