### PR TITLE
Import new @xmldom package

### DIFF
--- a/src/section.js
+++ b/src/section.js
@@ -4,7 +4,7 @@ import Hook from "./utils/hook";
 import { sprint } from "./utils/core";
 import { replaceBase } from "./utils/replacements";
 import Request from "./utils/request";
-import { DOMParser as XMLDOMSerializer } from "xmldom";
+import { DOMParser as XMLDOMSerializer } from "@xmldom/xmldom";
 
 /**
  * Represents a Section of the Book

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -2,7 +2,7 @@
  * Core Utilities and Helpers
  * @module Core
 */
-import { DOMParser as XMLDOMParser } from "xmldom";
+import { DOMParser as XMLDOMParser } from "@xmldom/xmldom";
 
 /**
  * Vendor prefixed requestAnimationFrame


### PR DESCRIPTION
https://github.com/futurepress/epub.js/commit/4f4155a8912e0e4c0870040ed972f4a69d75d1fa updated the xmldom package, but the package had changed name to @xmldom/xmldom. The import fields were not adjusted accordingly. Although it compiles in NPM without an error, when integrating this into a Quasar project and install with Yarn, the following error occurs:

```
frontend_1    |  App •  ERROR  •  UI  in ./node_modules/epubjs/src/section.js
frontend_1    | 
frontend_1    | Module not found: Can't resolve imported dependency "xmldom"
frontend_1    | Did you forget to install it? You can run: yarn add xmldom
frontend_1    | 
frontend_1    |  App •  ERROR  •  UI  in ./node_modules/epubjs/src/utils/core.js
frontend_1    | 
frontend_1    | Module not found: Can't resolve imported dependency "xmldom"
frontend_1    | Did you forget to install it? You can run: yarn add xmldom
```

This adjustment resolves the issue. 

Apologies @fchasen for this late amendment.