### PR TITLE
Allow `span` in toc nav items

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -191,7 +191,8 @@ class Navigation {
 	 */
 	navItem(item, parent) {
 		let id = item.getAttribute("id") || undefined;
-		let content = filterChildren(item, "a", true);
+		let content = filterChildren(item, "a", true)
+			|| filterChildren(item, "span", true);
 
 		if (!content) {
 			return;


### PR DESCRIPTION
According to https://www.w3.org/publishing/epub32/epub-packages.html#sec-package-nav-def-model:

> A child `a` element describes the target that the link points to, while a `span` element serves as a heading for breaking down lists into distinct groups (for example, a large list of illustrations can be segmented into several lists, one for each chapter).

Test case courtesy of @kianmeng: [no_nested_submenu_in_toc.zip](https://github.com/futurepress/epub.js/files/7725264/no_nested_submenu_in_toc.zip)

Evaluating `book.navigation.toc` without this fix: toc ignores all items marked with `span` and their subitems.
```json
[{"id":"intro.xhtml","href":"intro.xhtml","label":"Introduction","subitems":[]}]
```
With this fix: toc correctly contains all items.
```json
[{"id":"intro.xhtml","href":"intro.xhtml","label":"Introduction","subitems":[]},{"id":"","href":"","label":"Languages","subitems":[{"id":"intro.xhtml","href":"intro.xhtml","label":"Introduction","subitems":[],"parent":""},{"id":"about.xhtml","href":"about.xhtml","label":"About this book","subitems":[],"parent":""}]}]
```