### PR TITLE
Add location and percentage to DisplayedLocation

### DIFF
--- a/types/rendition.d.ts
+++ b/types/rendition.d.ts
@@ -32,6 +32,8 @@ export interface DisplayedLocation {
   index: number,
   href: string,
   cfi: string,
+  location: number,
+  percentage: number,
   displayed: {
     page: number,
     total: number


### PR DESCRIPTION
The content of DisplayedLocation actually looks like this:

![Screenshot from 2021-12-29 11-38-14](https://user-images.githubusercontent.com/7912190/147653769-50b7b69c-cc8e-4eb5-bb9d-126d4ebd80a6.png)
