### PR TITLE
Allow user to pass cached locations to `generate`

### DIFF
--- a/documentation/md/API.md
+++ b/documentation/md/API.md
@@ -435,6 +435,7 @@ Find Locations for a Book
 ### generate
 
 Load all of sections in the book to generate locations
+Allows passing a cached array locations to faster load percentages
 
 **Parameters**
 

--- a/examples/locations.html
+++ b/examples/locations.html
@@ -80,7 +80,10 @@
 				// Or generate the locations on the fly
 				// Can pass an option number of chars to break sections by
 				// default is 150 chars
-				return book.locations.generate(1600);
+				const cachedLocations = JSON.parse(localStorage.getItem('moby-dick-locations'));
+				const generatedLocations =  book.locations.generate(1600, cachedLocations);
+				localStorage.setItem('moby-dick-locations', JSON.stringify(generatedLocations));
+				return generatedLocations;
 			}
 		})
 		.then(function(locations){

--- a/src/locations.js
+++ b/src/locations.js
@@ -39,10 +39,21 @@ class Locations {
 	 * @param  {int} chars how many chars to split on
 	 * @return {object} locations
 	 */
-	generate(chars) {
+	generate(chars, cachedLocations) {
 
 		if (chars) {
 			this.break = chars;
+		}
+
+		if (cachedLocations && Array.isArray(cachedLocations)) {
+			this._locations = cachedLocations;
+			this.total = cachedLocations.length - 1;
+
+			if (this._currentCfi) {
+				this.currentLocation = this._currentCfi;
+			}
+
+			return this._locations;
 		}
 
 		this.q.pause();

--- a/types/locations.d.ts
+++ b/types/locations.d.ts
@@ -5,7 +5,7 @@ import EpubCFI from "./epubcfi";
 export default class Locations {
   constructor(spine: Spine, request?: Function, pause?: number);
 
-  generate(chars: number): object;
+  generate(chars: number, cachedLocations?: Array<string>): object;
 
   process(section: Section): Promise<Array<string>>;
 


### PR DESCRIPTION
## What's in this PR?

If you want to get percentages from a CFI, you have to first `generate` the locations. This can take a while, especially if the book is long, as every section has to be loaded. However, the resulting locations won't change between the first load and the second load.

Since `generate` returns those locations, a developer can cache those results (i.e. in localStorage). If they have a cached version, they should be able to pass it to `generate` to instantly load locations, rather than loading all sections again.

## How to test

I added an example in `locations.html`. The first time you load the book, it will take a bit to generate locations.
Refresh the page, and it should load almost instantly.