### PR TITLE
Remove check for script properties

### DIFF
--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -91,7 +91,7 @@ class IframeView {
 
 		// sandbox
 		this.iframe.sandbox = "allow-same-origin";
-		if (this.settings.allowScriptedContent && this.section.properties.indexOf("scripted") > -1) {
+		if (this.settings.allowScriptedContent) {
 			this.iframe.sandbox += " allow-scripts"
 		}
 


### PR DESCRIPTION
Fixes https://github.com/futurepress/epub.js/issues/1234 by making `allowScriptedContent` the only check for scripting. This re-enabled `addScript` while keeping books without `allowScriptedContent` more secure.

Will need to revisit this logic at somepoint to allow checking if a chapter has scripted content and throwing a warning if scripts are disabled.