### PR TITLE
feat: add `allowPopups` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8140,6 +8140,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -22,7 +22,8 @@ class ContinuousViewManager extends DefaultViewManager {
 			height: undefined,
 			snap: false,
 			afterScrolledTimeout: 10,
-			allowScriptedContent: false
+			allowScriptedContent: false,
+			allowPopups: false
 		});
 
 		extend(this.settings, options.settings || {});
@@ -40,7 +41,8 @@ class ContinuousViewManager extends DefaultViewManager {
 			width: 0,
 			height: 0,
 			forceEvenPages: false,
-			allowScriptedContent: this.settings.allowScriptedContent
+			allowScriptedContent: this.settings.allowScriptedContent,
+			allowPopups: this.settings.allowPopups
 		};
 
 		this.scrollTop = 0;
@@ -382,7 +384,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			} else {
 				if(this.settings.direction === 'rtl') {
 					if (!this.settings.fullsize) {
-						this.scrollTo(prevLeft, 0, true);					
+						this.scrollTo(prevLeft, 0, true);
 					} else {
 						this.scrollTo(prevLeft + Math.floor(bounds.width), 0, true);
 					}

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -27,7 +27,8 @@ class DefaultViewManager {
 			flow: "scrolled",
 			ignoreClass: "",
 			fullsize: undefined,
-			allowScriptedContent: false
+			allowScriptedContent: false,
+			allowPopups: false
 		});
 
 		extend(this.settings, options.settings || {});
@@ -41,7 +42,8 @@ class DefaultViewManager {
 			width: 0,
 			height: 0,
 			forceEvenPages: true,
-			allowScriptedContent: this.settings.allowScriptedContent
+			allowScriptedContent: this.settings.allowScriptedContent,
+			allowPopups: this.settings.allowPopups
 		};
 
 		this.rendered = false;
@@ -356,11 +358,11 @@ class DefaultViewManager {
 		}
 		if(this.settings.direction === 'rtl'){
 			/***
-				the `floor` function above (L343) is on positive values, so we should add one `layout.delta` 
+				the `floor` function above (L343) is on positive values, so we should add one `layout.delta`
 				to distX or use `Math.ceil` function, or multiply offset.left by -1
 				before `Math.floor`
 			*/
-			distX = distX + this.layout.delta 
+			distX = distX + this.layout.delta
 			distX = distX - width
 		}
 		this.scrollTo(distX, distY, true);
@@ -672,8 +674,8 @@ class DefaultViewManager {
 		let pageHeight = (container.height < window.innerHeight) ? container.height : window.innerHeight;
 		let pageWidth = (container.width < window.innerWidth) ? container.width : window.innerWidth;
 		let vertical = (this.settings.axis === "vertical");
-		let rtl =  (this.settings.direction === "rtl"); 
-			
+		let rtl =  (this.settings.direction === "rtl");
+		
 		let offset = 0;
 		let used = 0;
 

--- a/src/managers/views/iframe.js
+++ b/src/managers/views/iframe.js
@@ -17,7 +17,8 @@ class IframeView {
 			globalLayoutProperties: {},
 			method: undefined,
 			forceRight: false,
-			allowScriptedContent: false
+			allowScriptedContent: false,
+			allowPopups: false
 		}, options || {});
 
 		this.id = "epubjs-view-" + uuid();
@@ -92,9 +93,12 @@ class IframeView {
 		// sandbox
 		this.iframe.sandbox = "allow-same-origin";
 		if (this.settings.allowScriptedContent) {
-			this.iframe.sandbox += " allow-scripts"
+			this.iframe.sandbox += " allow-scripts";
 		}
-
+		if (this.settings.allowPopups) {
+			this.iframe.sandbox += " allow-popups";
+		}
+		
 		this.iframe.setAttribute("enable-annotation", "true");
 
 		this.resizing = true;
@@ -228,7 +232,7 @@ class IframeView {
 			this.lock("both", width, height);
 		} else if(this.settings.axis === "horizontal") {
 			this.lock("height", width, height);
-		} else {			
+		} else {
 			this.lock("width", width, height);
 		}
 

--- a/src/rendition.js
+++ b/src/rendition.js
@@ -38,6 +38,7 @@ import ContinuousViewManager from "./managers/continuous/index";
  * @param {boolean | object} [options.snap=false] use snap scrolling
  * @param {string} [options.defaultDirection='ltr'] default text direction
  * @param {boolean} [options.allowScriptedContent=false] enable running scripts in content
+ * @param {boolean} [options.allowPopups=false] enable opening popup in content
  */
 class Rendition {
 	constructor(book, options) {
@@ -57,7 +58,8 @@ class Rendition {
 			script: null,
 			snap: false,
 			defaultDirection: "ltr",
-			allowScriptedContent: false
+			allowScriptedContent: false,
+			allowPopups: false
 		});
 
 		extend(this.settings, options);


### PR DESCRIPTION
This PR aim to add `allowPopups` option.

`sandbox` attribute was introduces in https://github.com/futurepress/epub.js/pull/1222
`sandbox` apply allow list model. So, if any `sandbox` attributes exists, disable default features like `allow-popups`.

- [Play safely in sandboxed IFrames - HTML5 Rocks](https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/)
- [CSP: sandbox - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox)

Currently, we can not open external link from epub content.

For example, Click the link like`<a href="https://example.com" target="_blank">link</a>` and throw an error

> Blocked opening 'https://example.com' in a new window because the request was made in a sandboxed frame whose 'allow-popups' permission is not set.

The `allowPopups` allow user open the link.

**Test Plan**

1. Open http://localhost:8080/examples/input.html
2. Load epub content that include external link
3. Click the link in the cotent
