### PR TITLE
Prevent themes overlays on select theme

### DIFF
--- a/src/themes.js
+++ b/src/themes.js
@@ -133,6 +133,9 @@ class Themes {
 
 		contents = this.rendition.getContents();
 		contents.forEach( (content) => {
+			var previousStyleSheet = content._getStylesheetNode(prev);
+			previousStyleSheet.remove();
+
 			content.removeClass(prev);
 			content.addClass(name);
 		});


### PR DESCRIPTION
Fix for #1208 

Removes previous style-sheet and prevent style overlays.