### PR TITLE
Parse fallback attribute during parseManifest

### DIFF
--- a/src/packaging.js
+++ b/src/packaging.js
@@ -127,13 +127,15 @@ class Packaging {
 					type = item.getAttribute("media-type") || "",
 					overlay = item.getAttribute("media-overlay") || "",
 					properties = item.getAttribute("properties") || "";
+					fallback = item.getAttribute("fallback") || "";
 
 			manifest[id] = {
 				"href" : href,
 				// "url" : href,
 				"type" : type,
 				"overlay" : overlay,
-				"properties" : properties.length ? properties.split(" ") : []
+				"properties" : properties.length ? properties.split(" ") : [],
+				"fallback" : fallback,
 			};
 
 		});

--- a/types/packaging.d.ts
+++ b/types/packaging.d.ts
@@ -36,7 +36,8 @@ export interface PackagingSpineItem {
 export interface PackagingManifestItem {
   href: string,
   type: string,
-  properties: Array<string>
+  properties: Array<string>,
+  fallback: string
 }
 
 export interface PackagingManifestObject {


### PR DESCRIPTION
As defined in the spec: https://www.w3.org/TR/epub-33/#sec-manifest-fallbacks

The manifest item might contain a fallback attribute (https://www.w3.org/TR/epub-33/#attrdef-item-fallback)