### PR TITLE
Fix MathML example

### DIFF
--- a/examples/mathml.html
+++ b/examples/mathml.html
@@ -28,7 +28,8 @@
     var rendition = book.renderTo("viewer", {
       width: "100%",
       height: 600,
-      spread: "always"
+      spread: "always",
+      allowScriptedContent: true
     });
 
     rendition.display(currentSectionIndex);


### PR DESCRIPTION
`allowScriptedContent` is required for MathJax to run