### PR TITLE
Improved the bottom reaching detection.

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -493,9 +493,9 @@ class DefaultViewManager {
 
 			this.scrollTop = this.container.scrollTop;
 
-			let top  = this.container.scrollTop + this.container.offsetHeight;
+			const reachedToBottom = Math.abs(this.container.scrollHeight - this.container.clientHeight - this.container.scrollTop) < 1;
 
-			if(top < this.container.scrollHeight) {
+			if(!reachedToBottom) {
 				this.scrollBy(0, this.layout.height, true);
 			} else {
 				next = this.views.last().section.next();


### PR DESCRIPTION
Sometime I can't swipe to next chapter on vertical content.
I found that `top < this.container.scrollHeight` is always true on that broken situation. For example, top is 2199.99 and this.container.scrollHeight is 2200.

https://github.com/futurepress/epub.js/blob/3565e476c9806b6fc78108a65a6829c5c45c2c3b/src/managers/default/index.js#L496-L501

According to MDN, these numbers often have a floating decimal point.

> Note: This property will round the value to an integer. If you need a fractional value, use [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled

In my smartphone(Pixel 6a), certainly screen width is 412.19px and screen height is 790.09px.
![image](https://user-images.githubusercontent.com/18360/207262027-38747ff8-5a45-4e47-8c3b-7d934eb44acb.png)

I changed the calculation formula introduced on MDN, it will correctly determine that you have reached the bottom of the container element.
- https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled