### PR TITLE
list proper types for currentLocation

### DIFF
--- a/types/rendition.d.ts
+++ b/types/rendition.d.ts
@@ -75,8 +75,8 @@ export default class Rendition {
 
     clear(): void;
 
-    currentLocation(): DisplayedLocation;
-    currentLocation(): Promise<DisplayedLocation>;
+    currentLocation(): Location;
+    currentLocation(): Promise<Location>;
 
     destroy(): void;
 


### PR DESCRIPTION
## What's in this PR?

Fixes https://github.com/futurepress/epub.js/issues/1311

The types listed for `currentLocation()` on `rendition` were incorrect. The function returns a `Location`, which has a `start` and `end` of `DisplayedLocation`