### PR TITLE
Remove src from package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib
 dist
 documentation/html
 types/*.js
+epubjs-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-books
-test
-.babelrc

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "module": "src/index.js",
   "types": "types/index.d.ts",
   "repository": "https://github.com/futurepress/epub.js",
+  "files": [
+    "dist",
+    "lib",
+    "types",
+    "license",
+    "README.md"
+  ],
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This change should remove things such as tests, source files, and configuration files from the package. As far as I can tell, consumers of this package should have no use for any of these things.