### PR TITLE
Issue : #1384 Fix blank page when resize occurs before first page is rendered

### DIFF
--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -233,7 +233,7 @@ class DefaultViewManager {
 		this.emit(EVENTS.MANAGERS.RESIZED, {
 			width: this._stageSize.width,
 			height: this._stageSize.height
-		}, epubcfi);
+		}, epubcfi || this.target);
 	}
 
 	createView(section, forceRight) {
@@ -264,6 +264,9 @@ class DefaultViewManager {
 		if (target === section.href || isNumber(target)) {
 			target = undefined;
 		}
+
+		// If the window is resized before rendered, call resize with original target
+		this.target = target
 
 		// Check to make sure the section we want isn't already shown
 		var visible = this.views.find(section);
@@ -896,6 +899,8 @@ class DefaultViewManager {
 
 		this.scrollTop = scrollTop;
 		this.scrollLeft = scrollLeft;
+
+		this.target = undefined
 
 		if(!this.ignore) {
 			this.emit(EVENTS.MANAGERS.SCROLL, {

--- a/src/rendition.js
+++ b/src/rendition.js
@@ -476,8 +476,11 @@ class Rendition {
 			height: size.height
 		}, epubcfi);
 
-		if (this.location && this.location.start) {
-			this.display(epubcfi || this.location.start.cfi);
+		if (epubcfi) {
+			this.display(epubcfi)
+		}
+		else if (this.location && this.location.start) {
+			this.display(this.location.start.cfi);
 		}
 
 	}


### PR DESCRIPTION
I found an edge case pretty hard to reproduce.
When window.resize event is triggered while `book.renderTo(` is ongoing, the reader display a blank page with an empty div. 

To fix this bug, I suggest to save the initial target in the `manager`, and send the target during `resize`.
And to avoid the chapter to be reset to its initial position, I suggest to reset this initial target when the view scroll.