### PR TITLE
Update license file for GitHub UI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+BSD 2-Clause License
+
 Copyright (c) 2013, FuturePress
 
 All rights reserved.


### PR DESCRIPTION
GitHub uses [this](https://github.com/licensee/licensee/blob/main/docs/what-we-look-at.md) to display a license in the sidebar.

- filename `LICENSE` will be read
- adding `BSD 2-Clause License` to top will increase match %