### PR TITLE
Update replacements.js about function substitute

### DIFF
--- a/src/utils/replacements.js
+++ b/src/utils/replacements.js
@@ -128,6 +128,13 @@ export function replaceLinks(contents, fn) {
 export function substitute(content, urls, replacements) {
 	urls.forEach(function(url, i){
 		if (url && replacements[i]) {
+			// when (content.opf > manifest > item > href) is a encodeURI, but the content's source is not
+			try {
+				let decodeUri = window.decodeURIComponent(url);
+				content = content.replace(new RegExp(decodeUri, "g"), replacements[i]);
+			} catch (err) {
+				throw err
+			}
 			// Account for special characters in the file name.
 			// See https://stackoverflow.com/a/6318729.
 			url = url.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");


### PR DESCRIPTION
about function substitute
when (content.opf > manifest > item > href) is an encode-uri: '%E4%B8%AD%E6%96%87'

but the content's source is not:
'中文'

need decode

to substitute blob successfully

![微信图片_20240726163605](https://github.com/user-attachments/assets/8483dc09-53ce-4ff7-a4ec-23124d63a6eb)

