### PR TITLE
fix get navItem object bug by Navigation.get(target) method.

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -88,7 +88,8 @@ class Navigation {
 		}
 
 		if(target.indexOf("#") === 0) {
-			index = this.tocById[target.substring(1)];
+			target = target.substring(1);
+			index = this.tocById[target];
 		} else if(target in this.tocByHref){
 			index = this.tocByHref[target];
 		}


### PR DESCRIPTION
When I want to use the `get(target: string)` method in `navigation.js` to get the target navItem I encountered a bug, the method provides two means of querying based on the `id` or `href` attributes of the `navItem`, when I need to query based on the `id` I need to manually add the **#** character, while at this time the target is no longer equal to the id value of the target navItem. So I restore the target value **after** the determination is over:
https://github.com/futurepress/epub.js/blob/f09089cf77c55427bfdac7e0a4fa130e373a19c8/src/navigation.js#L90
and **before** calling getByIndex: 
https://github.com/futurepress/epub.js/blob/f09089cf77c55427bfdac7e0a4fa130e373a19c8/src/navigation.js#L96