### PR TITLE
fix: replace broken MDN SDK link with web archive

### DIFF
--- a/documentation/md/API.md
+++ b/documentation/md/API.md
@@ -429,7 +429,7 @@ Find Locations for a Book
 **Parameters**
 
 -   `spine` **[Spine](#spine)** 
--   `request` **[request](https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs/request)** 
+-   `request` **[request](https://web.archive.org/web/20201025030103/https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs/request)** 
 -   `pause` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)**  (optional, default `100`)
 
 ### generate


### PR DESCRIPTION
The MDN Add-on SDK documentation has been archived. The link to `/en-US/Add-ons/SDK/High-Level_APIs/request` now returns 404. 

This PR replaces it with a web archive version to preserve the documentation reference.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*